### PR TITLE
Add Atlas Cloud media provider tools

### DIFF
--- a/tests/tools/test_atlascloud_providers.py
+++ b/tests/tools/test_atlascloud_providers.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import jsonschema
+import pytest
+
+from tools.base_tool import ToolResult
+from tools.graphics.atlascloud_image import AtlasCloudImage
+from tools.video.atlascloud_video import AtlasCloudVideo
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        payload: dict | None = None,
+        content: bytes = b"fake media",
+    ) -> None:
+        self._payload = payload or {}
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _fail_network(*_args, **_kwargs):
+    raise AssertionError("network called before local input validation")
+
+
+def test_atlascloud_image_requires_project_output_path_before_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.setattr("requests.post", _fail_network)
+
+    result = AtlasCloudImage().execute(
+        {"prompt": "Product hero image", "output_path": "atlascloud.png"}
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.success
+    assert "output_path" in (result.error or "")
+    assert "projects/<project-name>/" in (result.error or "")
+
+
+def test_atlascloud_image_success_payload_matches_live_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    captured: dict[str, object] = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured["headers"] = kwargs["headers"]
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": "prediction-1", "status": "starting"}})
+
+    def fake_get(url, **_kwargs):
+        if url.endswith("/model/prediction/prediction-1"):
+            return _FakeResponse(
+                {
+                    "data": {
+                        "status": "completed",
+                        "outputs": ["https://cdn.example.test/atlascloud.png"],
+                    }
+                }
+            )
+        if url == "https://cdn.example.test/atlascloud.png":
+            return _FakeResponse(content=b"fake png")
+        raise AssertionError(f"unexpected GET {url}")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    output_path = "projects/demo/assets/images/atlascloud.png"
+    result = AtlasCloudImage().execute(
+        {
+            "prompt": "Product hero image",
+            "size": "2048*2048",
+            "output_format": "png",
+            "output_path": output_path,
+        }
+    )
+
+    assert result.success, result.error
+    assert captured["url"] == "https://api.atlascloud.ai/api/v1/model/generateImage"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["json"] == {
+        "model": "bytedance/seedream-v5.0-lite",
+        "prompt": "Product hero image",
+        "size": "2048*2048",
+        "output_format": "png",
+    }
+    assert (tmp_path / output_path).read_bytes() == b"fake png"
+    assert result.data["output_path"] == output_path
+    jsonschema.validate(instance=result.data, schema=AtlasCloudImage().output_schema)
+
+
+def test_atlascloud_video_image_to_video_requires_image_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", _fail_network)
+
+    result = AtlasCloudVideo().execute(
+        {"prompt": "Animate the product frame", "operation": "image_to_video"}
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.success
+    assert "image_to_video requires" in (result.error or "")
+
+
+def test_atlascloud_video_requires_project_output_path_before_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.setattr("requests.post", _fail_network)
+
+    result = AtlasCloudVideo().execute(
+        {"prompt": "A product hero shot", "output_path": "atlascloud.mp4"}
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.success
+    assert "output_path" in (result.error or "")
+    assert "projects/<project-name>/" in (result.error or "")
+
+
+def test_atlascloud_video_success_payload_matches_live_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "tools.video.atlascloud_video.probe_output",
+        lambda _path: {"file_size_bytes": 8},
+    )
+    captured: dict[str, object] = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured["headers"] = kwargs["headers"]
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": "prediction-2", "status": "starting"}})
+
+    def fake_get(url, **_kwargs):
+        if url.endswith("/model/prediction/prediction-2"):
+            return _FakeResponse(
+                {
+                    "data": {
+                        "status": "completed",
+                        "outputs": [{"url": "https://cdn.example.test/atlascloud.mp4"}],
+                    }
+                }
+            )
+        if url == "https://cdn.example.test/atlascloud.mp4":
+            return _FakeResponse(content=b"fake mp4")
+        raise AssertionError(f"unexpected GET {url}")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    output_path = "projects/demo/assets/video/atlascloud.mp4"
+    result = AtlasCloudVideo().execute(
+        {
+            "prompt": "A product hero shot",
+            "duration": 5,
+            "resolution": "720p",
+            "aspect_ratio": "16:9",
+            "generate_audio": True,
+            "seed": 123,
+            "output_path": output_path,
+        }
+    )
+
+    assert result.success, result.error
+    assert captured["url"] == "https://api.atlascloud.ai/api/v1/model/generateVideo"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["json"] == {
+        "model": "bytedance/seedance-2.0-fast/text-to-video",
+        "prompt": "A product hero shot",
+        "duration": 5,
+        "resolution": "720p",
+        "ratio": "16:9",
+        "bitrate_mode": "standard",
+        "generate_audio": True,
+        "watermark": False,
+        "seed": 123,
+    }
+    assert (tmp_path / output_path).read_bytes() == b"fake mp4"
+    assert result.data["output_path"] == output_path
+    assert result.data["format"] == "mp4"
+    jsonschema.validate(instance=result.data, schema=AtlasCloudVideo().output_schema)
+
+
+def test_atlascloud_video_image_to_video_uses_atlas_image_field(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "tools.video.atlascloud_video.probe_output",
+        lambda _path: {"file_size_bytes": 8},
+    )
+    captured: dict[str, object] = {}
+
+    def fake_post(_url, **kwargs):
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": "prediction-3", "status": "starting"}})
+
+    def fake_get(url, **_kwargs):
+        if url.endswith("/model/prediction/prediction-3"):
+            return _FakeResponse(
+                {
+                    "data": {
+                        "status": "completed",
+                        "output": "https://cdn.example.test/atlascloud-i2v.mp4",
+                    }
+                }
+            )
+        if url == "https://cdn.example.test/atlascloud-i2v.mp4":
+            return _FakeResponse(content=b"fake mp4")
+        raise AssertionError(f"unexpected GET {url}")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    result = AtlasCloudVideo().execute(
+        {
+            "prompt": "Animate the product frame",
+            "operation": "image_to_video",
+            "image_url": "https://example.test/frame.png",
+            "output_path": "projects/demo/assets/video/atlascloud-i2v.mp4",
+        }
+    )
+
+    assert result.success, result.error
+    assert captured["json"]["model"] == "bytedance/seedance-2.0-fast/image-to-video"
+    assert captured["json"]["image"] == "https://example.test/frame.png"
+    assert "image_url" not in captured["json"]
+
+
+def test_atlascloud_providers_are_discovered_by_registry(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    from tools.tool_registry import registry
+
+    registry.clear()
+    registry.discover()
+
+    assert registry.get("atlascloud_image").get_status().value == "available"
+    assert registry.get("atlascloud_video").get_status().value == "available"

--- a/tests/tools/test_cloud_video_providers.py
+++ b/tests/tools/test_cloud_video_providers.py
@@ -5,6 +5,7 @@ import pytest
 
 from lib.scoring import ProviderScore
 from tools.base_tool import ToolResult
+from tools.video.atlascloud_video import AtlasCloudVideo
 from tools.video.grok_video import GrokVideo
 from tools.video.heygen_video import HeyGenVideo
 from tools.video.higgsfield_video import HiggsFieldVideo
@@ -30,6 +31,7 @@ def _configure_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
     monkeypatch.setenv("HEYGEN_API_KEY", "test-heygen-key")
     monkeypatch.setenv("MODAL_LTX2_ENDPOINT_URL", "https://modal.example.test/ltx")
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
 
 
 def _fail_network(*_args, **_kwargs):
@@ -40,6 +42,7 @@ def _fail_network(*_args, **_kwargs):
     "tool",
     [
         KlingVideo(),
+        AtlasCloudVideo(),
         MiniMaxVideo(),
         RunwayVideo(),
         HiggsFieldVideo(),
@@ -66,6 +69,7 @@ def test_cloud_video_image_to_video_requires_image_before_network(
     "tool",
     [
         KlingVideo(),
+        AtlasCloudVideo(),
         MiniMaxVideo(),
         RunwayVideo(),
         HiggsFieldVideo(),
@@ -118,6 +122,7 @@ def test_minimax_fast_rejects_text_to_video_before_network(
     "tool",
     [
         KlingVideo(),
+        AtlasCloudVideo(),
         MiniMaxVideo(),
         RunwayVideo(),
         HiggsFieldVideo(),
@@ -169,6 +174,7 @@ def test_cloud_video_requires_project_output_path_before_network(
     ("tool", "env_vars"),
     [
         (GrokVideo(), ("XAI_API_KEY",)),
+        (AtlasCloudVideo(), ("ATLASCLOUD_API_KEY",)),
         (HeyGenVideo(), ("HEYGEN_API_KEY",)),
         (KlingVideo(), ("FAL_KEY", "FAL_AI_API_KEY")),
         (MiniMaxVideo(), ("MINIMAX_API_KEY",)),
@@ -205,6 +211,7 @@ def test_cloud_video_rejects_non_project_output_path_before_credentials(
     ("tool", "minimal_inputs"),
     [
         (GrokVideo(), {"prompt": "A product hero shot"}),
+        (AtlasCloudVideo(), {"prompt": "A product hero shot"}),
         (HeyGenVideo(), {"prompt": "A product hero shot"}),
         (HiggsFieldVideo(), {"prompt": "A product hero shot"}),
         (KlingVideo(), {"prompt": "A product hero shot"}),

--- a/tests/tools/test_image_providers.py
+++ b/tests/tools/test_image_providers.py
@@ -12,6 +12,7 @@ import pytest
 
 from lib.scoring import ProviderScore
 from tools.base_tool import ToolResult, ToolStatus
+from tools.graphics.atlascloud_image import AtlasCloudImage
 from tools.graphics.flux_image import FluxImage
 from tools.graphics.google_imagen import GoogleImagen
 from tools.graphics.grok_image import GrokImage
@@ -237,6 +238,11 @@ def test_wanx_requires_project_output_path_before_network(
     ("tool", "inputs", "env_vars"),
     [
         (FluxImage(), {"prompt": "product hero image", "output_path": "flux.png"}, ("FAL_KEY", "FAL_AI_API_KEY")),
+        (
+            AtlasCloudImage(),
+            {"prompt": "product hero image", "output_path": "atlascloud.png"},
+            ("ATLASCLOUD_API_KEY",),
+        ),
         (GoogleImagen(), {"prompt": "product hero image", "output_path": "imagen.png"}, ("GOOGLE_API_KEY", "GEMINI_API_KEY")),
         (GrokImage(), {"prompt": "product hero image", "output_path": "grok.png"}, ("XAI_API_KEY",)),
         (OpenAIImage(), {"prompt": "product hero image", "output_path": "openai.png"}, ("OPENAI_API_KEY",)),

--- a/tools/graphics/atlascloud_image.py
+++ b/tools/graphics/atlascloud_image.py
@@ -1,0 +1,308 @@
+"""Atlas Cloud image generation via the Media Generation API.
+
+Uses Atlas Cloud's async task flow:
+submit image generation -> poll prediction -> download image.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.output_paths import require_explicit_output_path
+
+_DEFAULT_MEDIA_BASE_URL = "https://api.atlascloud.ai/api/v1"
+_DEFAULT_MODEL = "bytedance/seedream-v5.0-lite"
+_MODEL_SOURCE_URL = "https://api.atlascloud.ai/api/v1/models"
+_SCHEMA_SOURCE_URL = (
+    "https://static.atlascloud.ai/model/schema/bytedance-seedream-v5.0-lite.json"
+)
+_SIZES = [
+    "2048*2048",
+    "2304*1728",
+    "1728*2304",
+    "2848*1600",
+    "1600*2848",
+    "2496*1664",
+    "1664*2496",
+    "3136*1344",
+    "3072*3072",
+    "3456*2592",
+    "2592*3456",
+    "4096*2304",
+    "2304*4096",
+    "2496*3744",
+    "3744*2496",
+    "4704*2016",
+]
+
+
+def _api_key() -> str | None:
+    return os.environ.get("ATLASCLOUD_API_KEY") or os.environ.get("ATLAS_CLOUD_API_KEY")
+
+
+def _media_base_url() -> str:
+    return os.environ.get("ATLASCLOUD_MEDIA_API_BASE", _DEFAULT_MEDIA_BASE_URL).rstrip("/")
+
+
+def _prediction_id(payload: dict[str, Any]) -> str | None:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+    for key in ("id", "prediction_id", "request_id", "task_id"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _status_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        return data
+    return payload
+
+
+def _collect_urls(value: Any) -> list[str]:
+    urls: list[str] = []
+    if isinstance(value, str):
+        if value.startswith(("http://", "https://")):
+            urls.append(value)
+        return urls
+    if isinstance(value, list):
+        for item in value:
+            urls.extend(_collect_urls(item))
+        return urls
+    if isinstance(value, dict):
+        for key in ("url", "image", "image_url", "download_url", "output_url"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate.startswith(
+                ("http://", "https://")
+            ):
+                urls.append(candidate)
+        for key in ("outputs", "output", "result", "results", "images", "data"):
+            if key in value:
+                urls.extend(_collect_urls(value[key]))
+    return urls
+
+
+class AtlasCloudImage(BaseTool):
+    name = "atlascloud_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "atlascloud"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["env:ATLASCLOUD_API_KEY"]
+    install_instructions = (
+        "Set ATLASCLOUD_API_KEY to your Atlas Cloud API key.\n"
+        "  Get one at https://www.atlascloud.ai/console/api-keys"
+    )
+    agent_skills = ["atlas-cloud"]
+
+    capabilities = ["generate_image", "text_to_image"]
+    supports = {
+        "text_to_image": True,
+        "custom_size": True,
+        "seed": False,
+    }
+    best_for = [
+        "2K and 3K production stills through Atlas Cloud's Media Generation API",
+        "teams that want one Atlas Cloud key for both image and video generation",
+        "Seedream v5.0 Lite image generation with jpeg/png output",
+    ]
+    not_good_for = ["offline generation", "image editing"]
+    fallback_tools = ["wanx_image", "openai_image", "flux_image"]
+    model_options = [
+        {
+            "id": _DEFAULT_MODEL,
+            "name": "Seedream v5.0 Lite",
+            "field": "model",
+            "default": True,
+            "quality": "high",
+            "speed": "fast",
+            "cost_hint": {"usd": 0.032, "unit": "per_image"},
+            "last_verified": "2026-07-22",
+            "source_url": _MODEL_SOURCE_URL,
+            "schema_url": _SCHEMA_SOURCE_URL,
+        }
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt", "output_path"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "model": {
+                "type": "string",
+                "enum": [_DEFAULT_MODEL],
+                "default": _DEFAULT_MODEL,
+            },
+            "size": {
+                "type": "string",
+                "enum": _SIZES,
+                "default": "2048*2048",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["jpeg", "png"],
+                "default": "jpeg",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "required": [
+            "provider",
+            "model",
+            "prompt",
+            "size",
+            "output_format",
+            "output",
+            "output_path",
+        ],
+        "properties": {
+            "provider": {"type": "string", "const": "atlascloud"},
+            "model": {"type": "string"},
+            "prompt": {"type": "string"},
+            "size": {"type": "string"},
+            "output_format": {"type": "string"},
+            "prediction_id": {"type": "string"},
+            "output": {"type": "string"},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "size", "output_format", "output_path"]
+    side_effects = ["writes image file to output_path", "calls Atlas Cloud Media API"]
+    user_visible_verification = ["Inspect generated image for relevance and quality"]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if _api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.032
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        model = inputs.get("model", _DEFAULT_MODEL)
+        if model != _DEFAULT_MODEL:
+            return ToolResult(success=False, error=f"Unsupported model {model!r}.")
+
+        output_path, output_error = require_explicit_output_path(
+            inputs, self.name, artifact_label="generated image"
+        )
+        if output_error:
+            return output_error
+
+        api_key = _api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="ATLASCLOUD_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+
+        start = time.time()
+        payload = {
+            "model": model,
+            "prompt": inputs["prompt"],
+            "size": inputs.get("size", "2048*2048"),
+            "output_format": inputs.get("output_format", "jpeg"),
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            submit = requests.post(
+                f"{_media_base_url()}/model/generateImage",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            submit.raise_for_status()
+            task_id = _prediction_id(submit.json())
+            if not task_id:
+                return ToolResult(
+                    success=False,
+                    error="Atlas Cloud image generation returned no prediction id",
+                )
+
+            result_payload = self._poll_prediction(task_id, headers)
+            urls = _collect_urls(result_payload)
+            if not urls:
+                return ToolResult(
+                    success=False,
+                    error="Atlas Cloud image generation completed without an output URL",
+                )
+
+            image_response = requests.get(urls[0], timeout=120)
+            image_response.raise_for_status()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(image_response.content)
+
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Atlas Cloud image generation failed: {exc}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "prompt": inputs["prompt"],
+                "size": payload["size"],
+                "output_format": payload["output_format"],
+                "prediction_id": task_id,
+                "output": str(output_path),
+                "output_path": str(output_path),
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )
+
+    def _poll_prediction(self, task_id: str, headers: dict[str, str]) -> dict[str, Any]:
+        import requests
+
+        deadline = time.time() + 300
+        while True:
+            response = requests.get(
+                f"{_media_base_url()}/model/prediction/{task_id}",
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            data = _status_payload(payload)
+            status = str(data.get("status", "")).lower()
+            if status in {"completed", "succeeded", "success"}:
+                return data
+            if status in {"failed", "error", "canceled", "cancelled"}:
+                message = data.get("error") or data.get("message") or status
+                raise RuntimeError(f"Atlas Cloud image generation {message}")
+            if time.time() >= deadline:
+                raise TimeoutError("Atlas Cloud image generation timed out")
+            time.sleep(3)

--- a/tools/video/atlascloud_video.py
+++ b/tools/video/atlascloud_video.py
@@ -1,0 +1,572 @@
+"""Atlas Cloud video generation via the Media Generation API.
+
+Uses Atlas Cloud's async task flow:
+submit video generation -> poll prediction -> download video.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video._shared import probe_output, require_generated_video_output_path
+
+_DEFAULT_MEDIA_BASE_URL = "https://api.atlascloud.ai/api/v1"
+_MODEL_SOURCE_URL = "https://api.atlascloud.ai/api/v1/models"
+_TEXT_MODEL = "bytedance/seedance-2.0-fast/text-to-video"
+_IMAGE_MODEL = "bytedance/seedance-2.0-fast/image-to-video"
+_REFERENCE_MODEL = "bytedance/seedance-2.0-fast/reference-to-video"
+_OP_DEFAULTS = {
+    "text_to_video": _TEXT_MODEL,
+    "image_to_video": _IMAGE_MODEL,
+    "reference_to_video": _REFERENCE_MODEL,
+}
+_MODELS: dict[str, dict[str, Any]] = {
+    _TEXT_MODEL: {
+        "name": "Seedance 2.0 Fast Text-to-Video",
+        "operation": "text_to_video",
+        "quality": "high",
+        "speed": "fast",
+        "cost_per_generation": 0.072,
+        "last_verified": "2026-07-22",
+        "schema_url": (
+            "https://static.atlascloud.ai/model/schema/"
+            "bytedance-seedance-2.0-fast-text-to-video.json"
+        ),
+    },
+    _IMAGE_MODEL: {
+        "name": "Seedance 2.0 Fast Image-to-Video",
+        "operation": "image_to_video",
+        "quality": "high",
+        "speed": "fast",
+        "cost_per_generation": 0.072,
+        "last_verified": "2026-07-22",
+        "schema_url": (
+            "https://static.atlascloud.ai/model/schema/"
+            "bytedance-seedance-2.0-fast-image-to-video.json"
+        ),
+    },
+    _REFERENCE_MODEL: {
+        "name": "Seedance 2.0 Fast Reference-to-Video",
+        "operation": "reference_to_video",
+        "quality": "high",
+        "speed": "fast",
+        "cost_per_generation": 0.072,
+        "last_verified": "2026-07-22",
+        "schema_url": (
+            "https://static.atlascloud.ai/model/schema/"
+            "bytedance-seedance-2.0-fast-reference-to-video.json"
+        ),
+    },
+}
+_DURATIONS = [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+_RESOLUTIONS = ["480p", "720p", "720p-SR", "1080p-SR", "1440p-SR"]
+_RATIOS = ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"]
+
+
+def _api_key() -> str | None:
+    return os.environ.get("ATLASCLOUD_API_KEY") or os.environ.get("ATLAS_CLOUD_API_KEY")
+
+
+def _media_base_url() -> str:
+    return os.environ.get("ATLASCLOUD_MEDIA_API_BASE", _DEFAULT_MEDIA_BASE_URL).rstrip("/")
+
+
+def _prediction_id(payload: dict[str, Any]) -> str | None:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+    for key in ("id", "prediction_id", "request_id", "task_id"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _status_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        return data
+    return payload
+
+
+def _collect_urls(value: Any) -> list[str]:
+    urls: list[str] = []
+    if isinstance(value, str):
+        if value.startswith(("http://", "https://")):
+            urls.append(value)
+        return urls
+    if isinstance(value, list):
+        for item in value:
+            urls.extend(_collect_urls(item))
+        return urls
+    if isinstance(value, dict):
+        for key in ("url", "video", "video_url", "download_url", "output_url"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate.startswith(
+                ("http://", "https://")
+            ):
+                urls.append(candidate)
+        for key in ("outputs", "output", "result", "results", "videos", "data"):
+            if key in value:
+                urls.extend(_collect_urls(value[key]))
+    return urls
+
+
+class AtlasCloudVideo(BaseTool):
+    name = "atlascloud_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "atlascloud"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["env:ATLASCLOUD_API_KEY"]
+    install_instructions = (
+        "Set ATLASCLOUD_API_KEY to your Atlas Cloud API key.\n"
+        "  Get one at https://www.atlascloud.ai/console/api-keys"
+    )
+    agent_skills = ["atlas-cloud", "ai-video-gen"]
+
+    capabilities = ["text_to_video", "image_to_video", "reference_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "reference_to_video": True,
+        "multiple_reference_images": True,
+        "reference_image": True,
+        "native_audio": True,
+        "aspect_ratio": True,
+        "seed": True,
+    }
+    best_for = [
+        "Atlas Cloud Seedance 2.0 Fast video generation with one API key",
+        "text-to-video, image-to-video, and reference-conditioned video workflows",
+        "short production clips with synchronized audio and live Atlas Cloud model routing",
+    ]
+    not_good_for = ["offline generation", "long-form video rendering"]
+    fallback_tools = ["seedance_video", "wan_video_api", "kling_video"]
+    quality_score = 0.9
+    model_options = [
+        {
+            "id": model_id,
+            "name": meta["name"],
+            "field": "model_variant",
+            "default_for_operations": [meta["operation"]],
+            "operation": meta["operation"],
+            "quality": meta["quality"],
+            "speed": meta["speed"],
+            "cost_hint": {"usd": meta["cost_per_generation"], "unit": "per_generation"},
+            "last_verified": meta["last_verified"],
+            "source_url": _MODEL_SOURCE_URL,
+            "schema_url": meta["schema_url"],
+        }
+        for model_id, meta in _MODELS.items()
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt", "output_path"],
+        "allOf": [
+            {
+                "if": {
+                    "properties": {"operation": {"const": "image_to_video"}},
+                    "required": ["operation"],
+                },
+                "then": {
+                    "anyOf": [
+                        {"required": ["image"]},
+                        {"required": ["image_url"]},
+                    ]
+                },
+            },
+            {
+                "if": {
+                    "properties": {"operation": {"const": "reference_to_video"}},
+                    "required": ["operation"],
+                },
+                "then": {
+                    "anyOf": [
+                        {"required": ["reference_image_urls"]},
+                        {"required": ["reference_video_urls"]},
+                        {"required": ["reference_audio_urls"]},
+                    ]
+                },
+            },
+        ],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video", "reference_to_video"],
+                "default": "text_to_video",
+            },
+            "model_variant": {
+                "type": "string",
+                "enum": list(_MODELS),
+                "description": "Atlas Cloud Seedance model id. Omit to use the operation default.",
+            },
+            "model": {
+                "type": "string",
+                "enum": list(_MODELS),
+                "description": "Alias for model_variant.",
+            },
+            "duration": {
+                "type": "integer",
+                "enum": _DURATIONS,
+                "default": 5,
+                "description": "Duration in seconds, or -1 to let the model decide.",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": _RESOLUTIONS,
+                "default": "720p",
+            },
+            "ratio": {
+                "type": "string",
+                "enum": _RATIOS,
+                "default": "adaptive",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": _RATIOS,
+                "default": "adaptive",
+                "description": "Selector-friendly alias mapped to Atlas Cloud's ratio field.",
+            },
+            "bitrate_mode": {
+                "type": "string",
+                "enum": ["standard", "high"],
+                "default": "standard",
+            },
+            "generate_audio": {"type": "boolean", "default": True},
+            "seed": {"type": "integer", "minimum": -1, "maximum": 4294967295},
+            "watermark": {"type": "boolean", "default": False},
+            "image": {
+                "type": "string",
+                "description": "First-frame image URL, Base64, or asset reference for image_to_video.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Alias for image. Atlas Cloud accepts image URLs in the image field.",
+            },
+            "last_image": {
+                "type": "string",
+                "description": "Optional last-frame image URL, Base64, or asset reference.",
+            },
+            "last_image_url": {
+                "type": "string",
+                "description": "Alias for last_image.",
+            },
+            "reference_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 9,
+            },
+            "reference_video_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 3,
+            },
+            "reference_audio_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 3,
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "required": [
+            "provider",
+            "model",
+            "prompt",
+            "operation",
+            "duration",
+            "resolution",
+            "ratio",
+            "generate_audio",
+            "seed",
+            "output",
+            "output_path",
+            "format",
+        ],
+        "properties": {
+            "provider": {"type": "string", "const": "atlascloud"},
+            "model": {"type": "string"},
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video", "reference_to_video"],
+            },
+            "duration": {"type": "integer"},
+            "resolution": {"type": "string"},
+            "ratio": {"type": "string"},
+            "bitrate_mode": {"type": "string"},
+            "generate_audio": {"type": "boolean"},
+            "seed": {"type": ["integer", "null"]},
+            "prediction_id": {"type": "string"},
+            "output": {"type": "string"},
+            "output_path": {"type": "string"},
+            "format": {"type": "string", "const": "mp4"},
+            "file_size_bytes": {"type": "integer", "minimum": 0},
+            "duration_seconds": {"type": "number", "minimum": 0},
+            "file_size_mb": {"type": "number", "minimum": 0},
+            "video_width": {"type": "integer", "minimum": 0},
+            "video_height": {"type": "integer", "minimum": 0},
+            "video_codec": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = [
+        "prompt",
+        "output_path",
+        "model_variant",
+        "model",
+        "operation",
+        "duration",
+        "resolution",
+        "ratio",
+        "aspect_ratio",
+        "bitrate_mode",
+        "generate_audio",
+        "seed",
+        "watermark",
+        "image",
+        "image_url",
+        "last_image",
+        "last_image_url",
+        "reference_image_urls",
+        "reference_video_urls",
+        "reference_audio_urls",
+    ]
+    side_effects = ["writes video file to output_path", "calls Atlas Cloud Media API"]
+    user_visible_verification = ["Inspect sampled frames for motion coherence and visual quality"]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if _api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        operation = inputs.get("operation", "text_to_video")
+        model = (
+            inputs.get("model_variant")
+            or inputs.get("model")
+            or _OP_DEFAULTS.get(operation, _TEXT_MODEL)
+        )
+        return float(_MODELS.get(str(model), _MODELS[_TEXT_MODEL])["cost_per_generation"])
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 90.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        operation = inputs.get("operation", "text_to_video")
+        if operation not in _OP_DEFAULTS:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Unknown operation {operation!r}. Valid values: "
+                    f"{', '.join(sorted(_OP_DEFAULTS))}."
+                ),
+            )
+
+        model = inputs.get("model_variant") or inputs.get("model") or _OP_DEFAULTS[operation]
+        if model not in _MODELS:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Unknown model_variant {model!r}. "
+                    f"Available: {', '.join(sorted(_MODELS))}."
+                ),
+            )
+        model_operation = _MODELS[model]["operation"]
+        if model_operation != operation:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"model_variant {model!r} supports {model_operation}, "
+                    f"but operation is {operation}. Choose a matching model_variant "
+                    "or omit model_variant to use the operation default."
+                ),
+            )
+
+        validation_error = self._validate_conditioning_inputs(inputs, operation)
+        if validation_error:
+            return ToolResult(success=False, error=validation_error)
+
+        output_path, output_error = require_generated_video_output_path(inputs, self.name)
+        if output_error:
+            return output_error
+
+        api_key = _api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="ATLASCLOUD_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+
+        start = time.time()
+        payload = self._build_payload(inputs, str(model), operation)
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            submit = requests.post(
+                f"{_media_base_url()}/model/generateVideo",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            submit.raise_for_status()
+            task_id = _prediction_id(submit.json())
+            if not task_id:
+                return ToolResult(
+                    success=False,
+                    error="Atlas Cloud video generation returned no prediction id",
+                )
+
+            result_payload = self._poll_prediction(task_id, headers)
+            urls = _collect_urls(result_payload)
+            if not urls:
+                return ToolResult(
+                    success=False,
+                    error="Atlas Cloud video generation completed without an output URL",
+                )
+
+            video_response = requests.get(urls[0], timeout=300)
+            video_response.raise_for_status()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(video_response.content)
+
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Atlas Cloud video generation failed: {exc}")
+
+        probed = probe_output(output_path)
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "prompt": inputs["prompt"],
+                "operation": operation,
+                "duration": payload.get("duration", 5),
+                "resolution": payload.get("resolution", "720p"),
+                "ratio": payload.get("ratio", "adaptive"),
+                "bitrate_mode": payload.get("bitrate_mode", "standard"),
+                "generate_audio": payload.get("generate_audio", True),
+                "seed": payload.get("seed"),
+                "prediction_id": task_id,
+                "output": str(output_path),
+                "output_path": str(output_path),
+                "format": "mp4",
+                **probed,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            seed=payload.get("seed"),
+            model=str(model),
+        )
+
+    def _build_payload(
+        self,
+        inputs: dict[str, Any],
+        model: str,
+        operation: str,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": inputs["prompt"],
+            "duration": inputs.get("duration", 5),
+            "resolution": inputs.get("resolution", "720p"),
+            "ratio": inputs.get("ratio") or inputs.get("aspect_ratio", "adaptive"),
+            "bitrate_mode": inputs.get("bitrate_mode", "standard"),
+            "generate_audio": inputs.get("generate_audio", True),
+            "watermark": inputs.get("watermark", False),
+        }
+        if inputs.get("seed") is not None:
+            payload["seed"] = inputs["seed"]
+
+        if operation == "image_to_video":
+            payload["image"] = inputs.get("image") or inputs.get("image_url")
+            if inputs.get("last_image") or inputs.get("last_image_url"):
+                payload["last_image"] = inputs.get("last_image") or inputs.get("last_image_url")
+
+        if operation == "reference_to_video":
+            if inputs.get("reference_image_urls"):
+                payload["reference_images"] = inputs["reference_image_urls"]
+            if inputs.get("reference_video_urls"):
+                payload["reference_videos"] = inputs["reference_video_urls"]
+            if inputs.get("reference_audio_urls"):
+                payload["reference_audios"] = inputs["reference_audio_urls"]
+
+        return payload
+
+    @staticmethod
+    def _validate_conditioning_inputs(
+        inputs: dict[str, Any],
+        operation: str,
+    ) -> str | None:
+        if operation == "image_to_video" and not (inputs.get("image") or inputs.get("image_url")):
+            return "image_to_video requires image or image_url"
+        if operation == "reference_to_video":
+            if not any(
+                inputs.get(key)
+                for key in (
+                    "reference_image_urls",
+                    "reference_video_urls",
+                    "reference_audio_urls",
+                )
+            ):
+                return (
+                    "reference_to_video requires reference_image_urls, "
+                    "reference_video_urls, or reference_audio_urls"
+                )
+        return None
+
+    def _poll_prediction(self, task_id: str, headers: dict[str, str]) -> dict[str, Any]:
+        import requests
+
+        deadline = time.time() + 600
+        while True:
+            response = requests.get(
+                f"{_media_base_url()}/model/prediction/{task_id}",
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            data = _status_payload(payload)
+            status = str(data.get("status", "")).lower()
+            if status in {"completed", "succeeded", "success"}:
+                return data
+            if status in {"failed", "error", "canceled", "cancelled"}:
+                message = data.get("error") or data.get("message") or status
+                raise RuntimeError(f"Atlas Cloud video generation {message}")
+            if time.time() >= deadline:
+                raise TimeoutError("Atlas Cloud video generation timed out")
+            time.sleep(5)


### PR DESCRIPTION
## Summary
- add Atlas Cloud image generation support through the Media Generation API using the live-verified Seedream v5.0 Lite model
- add Atlas Cloud video generation support for Seedance 2.0 Fast text-to-video, image-to-video, and reference-to-video models
- cover local validation, payload mapping, polling/download flow, and registry discovery with focused tests

## Verification
- fetched the live Atlas Cloud model list and schemas for the configured image/video models on 2026-07-22
- .......                                                                  [100%]
7 passed in 0.19s (7 passed)
- ........................................................................ [ 80%]
..................                                                       [100%]
90 passed in 0.13s (90 passed)
- 
- 

No README changes.