### PR TITLE
fix(checkpoint): normalize decision log references

### DIFF
--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -1014,7 +1014,7 @@ def write_checkpoint(
     # reference back into relevant artifacts so downstream consumers can find it.
     if "decision_log" in artifacts and isinstance(artifacts["decision_log"], dict):
         _merge_decision_log(pipeline_dir, project_id, artifacts["decision_log"])
-        log_ref = str(_decision_log_path(pipeline_dir, project_id))
+        log_ref = _decision_log_path(pipeline_dir, project_id).as_posix()
 
         # Write decision_log_ref into proposal/render artifacts when present.
         for artifact_key in ("proposal_packet", "production_proposal", "render_report"):

--- a/tests/contracts/test_ad_video_manifest_skills.py
+++ b/tests/contracts/test_ad_video_manifest_skills.py
@@ -6,7 +6,7 @@ import json
 import re
 import shutil
 from copy import deepcopy
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -1931,6 +1931,47 @@ def test_ad_video_production_proposal_checkpoint_records_decision_log_ref(tmp_pa
 
     proposal = checkpoint["artifacts"]["production_proposal"]
     assert proposal["decision_log_ref"].endswith("ad-proposal-ref/decision_log.json")
+
+
+def test_ad_video_decision_log_ref_normalizes_windows_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lib.checkpoint as checkpoint_module
+
+    monkeypatch.setattr(
+        checkpoint_module,
+        "_merge_decision_log",
+        lambda pipeline_dir, project_id, decision_log: None,
+    )
+    monkeypatch.setattr(
+        checkpoint_module,
+        "_decision_log_path",
+        lambda pipeline_dir, project_id: PureWindowsPath(
+            rf"C:\projects\{project_id}\decision_log.json"
+        ),
+    )
+
+    checkpoint_path = checkpoint_module.write_checkpoint(
+        tmp_path,
+        "ad-proposal-ref",
+        "proposal",
+        "in_progress",
+        {
+            "production_proposal": _minimal_production_proposal(),
+            "decision_log": {
+                "version": "1.0",
+                "project_id": "ad-proposal-ref",
+                "decisions": [],
+            },
+        },
+        pipeline_type="ad-video",
+    )
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+
+    assert checkpoint["artifacts"]["production_proposal"]["decision_log_ref"] == (
+        "C:/projects/ad-proposal-ref/decision_log.json"
+    )
 
 
 def test_ad_video_publish_declares_artifacts_needed_for_final_safety_review() -> None:


### PR DESCRIPTION
## Summary

Normalize persisted `decision_log_ref` paths to POSIX-style separators so checkpoint artifacts remain portable across Windows and POSIX platforms.

## Related issue

N/A

## Changes

- Serialize `decision_log_ref` with `Path.as_posix()`.
- Add a platform-independent `PureWindowsPath` regression test.
- Preserve the existing checkpoint and decision-log behavior.

## Testing

- Focused decision log reference tests: 2 passed
- `tests/contracts/test_ad_video_manifest_skills.py`: 77 passed
- Full UTF-8 contract suite: 1210 passed
- 4 unrelated existing failures remain in `test_agent_components.py` due to `master`/`main` fixture assumptions
- Python compilation passed
- `git diff --check` passed

## Checklist

- [x] The change addresses one focused cross-platform issue.
- [x] Regression coverage works on Linux and Windows.
- [x] No generated media, API keys, or local project files are included.