### PR TITLE
fix(components): stabilize tree hashes on Windows

### DIFF
--- a/lib/agent_components/__init__.py
+++ b/lib/agent_components/__init__.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Iterable
 
 import yaml
@@ -748,7 +748,12 @@ def _hash_tree(root: Path) -> dict[str, Any]:
         raise ComponentError(f"source tree is not a directory: {root}")
     files = []
     tree_hasher = hashlib.sha256()
-    for path in sorted(p for p in root.rglob("*") if p.is_file() and not _is_ignored_component_file(p, root)):
+    component_files = (
+        path
+        for path in root.rglob("*")
+        if path.is_file() and not _is_ignored_component_file(path, root)
+    )
+    for path in sorted(component_files, key=lambda item: _component_tree_sort_key(item, root)):
         rel = path.relative_to(root).as_posix()
         digest = _sha256_file(path)
         mode = _locked_file_mode(path)
@@ -757,6 +762,11 @@ def _hash_tree(root: Path) -> dict[str, Any]:
         tree_hasher.update(mode.encode("ascii") + b"\0")
         tree_hasher.update(digest.encode("ascii") + b"\0")
     return {"treeSha256": f"sha256:{tree_hasher.hexdigest()}", "files": files}
+
+
+def _component_tree_sort_key(path: PurePath, root: PurePath) -> tuple[str, ...]:
+    """Return a case-sensitive path-parts key independent of host path flavor."""
+    return path.relative_to(root).parts
 
 
 def _is_ignored_component_file(path: Path, root: Path) -> bool:

--- a/tests/contracts/test_agent_components.py
+++ b/tests/contracts/test_agent_components.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import jsonschema
 import pytest
@@ -110,6 +110,42 @@ sources:
     raw = lock_path.read_text(encoding="utf-8")
     assert json.loads(raw) == lock
     assert raw.endswith("\n")
+
+
+def test_component_tree_sort_key_is_portable_on_windows() -> None:
+    from lib.agent_components import _component_tree_sort_key
+
+    root = PureWindowsPath("C:/component")
+    paths = [
+        root / "references" / "guide.md",
+        root / "references.md",
+        root / "SKILL.md",
+        root / "examples" / "Demo.md",
+    ]
+
+    sorted_paths = sorted(paths, key=lambda path: _component_tree_sort_key(path, root))
+
+    assert [path.relative_to(root).as_posix() for path in sorted_paths] == [
+        "SKILL.md",
+        "examples/Demo.md",
+        "references/guide.md",
+        "references.md",
+    ]
+
+
+def test_checked_in_local_component_tree_hash_matches_lock() -> None:
+    from lib.agent_components import _hash_tree
+
+    repo_root = Path(__file__).resolve().parents[2]
+    lock = json.loads(
+        (repo_root / ".agents" / "components.lock.json").read_text(encoding="utf-8")
+    )
+    entry = lock["components"]["agents"]
+
+    actual = _hash_tree(repo_root / entry["sourcePath"])
+
+    assert actual["treeSha256"] == entry["treeSha256"]
+    assert actual["files"] == entry["files"]
 
 
 def test_load_lock_rejects_non_strict_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- sort component files using case-sensitive relative path parts
- keep tree hashes stable across Windows and Linux
- preserve the existing Linux lockfile ordering for directory/file prefix cases
- add PureWindowsPath and checked-in lock regression coverage

## Problem

Windows Path ordering is case-insensitive. This caused identical component
files to produce different tree hashes from the Linux-generated lockfile,
breaking frozen component installation and verification on Windows.

## Testing

- Focused tree-hash regressions: 2 passed
- Full contracts: 1212 passed, 4 pre-existing Windows Git fixture failures,
  1 deselected
- All checked-in local component hash mismatches reduced from 24 to 0
- `git diff --check` passed
