### PR TITLE
test(components): make git fixtures branch-independent

### DIFF
--- a/tests/contracts/test_agent_components.py
+++ b/tests/contracts/test_agent_components.py
@@ -396,7 +396,11 @@ def test_git_mirror_clone_retries_transient_failure(
 
     upstream = tmp_path / "upstream"
     _write_skill(upstream / "skills", "demo", "from retry")
-    subprocess.run(["git", "init", str(upstream)], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "init", "--initial-branch=master", str(upstream)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
     subprocess.run(["git", "-C", str(upstream), "config", "user.email", "test@example.com"], check=True)
     subprocess.run(["git", "-C", str(upstream), "config", "user.name", "Test"], check=True)
     subprocess.run(["git", "-C", str(upstream), "add", "."], check=True)
@@ -456,7 +460,11 @@ def test_git_source_fetches_shared_source_once_per_lock_run(tmp_path: Path, monk
     upstream = tmp_path / "upstream"
     _write_skill(upstream / "skills", "first", "from git")
     _write_skill(upstream / "skills", "second", "from git")
-    subprocess.run(["git", "init", str(upstream)], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "init", "--initial-branch=master", str(upstream)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
     subprocess.run(["git", "-C", str(upstream), "config", "user.email", "test@example.com"], check=True)
     subprocess.run(["git", "-C", str(upstream), "config", "user.name", "Test"], check=True)
     subprocess.run(["git", "-C", str(upstream), "add", "."], check=True)
@@ -510,7 +518,11 @@ def test_frozen_offline_verify_uses_locked_git_commit_after_ref_moves(tmp_path: 
 
     upstream = tmp_path / "upstream"
     _write_skill(upstream / "skills", "demo", "from git")
-    subprocess.run(["git", "init", str(upstream)], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "init", "--initial-branch=master", str(upstream)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
     subprocess.run(["git", "-C", str(upstream), "config", "user.email", "test@example.com"], check=True)
     subprocess.run(["git", "-C", str(upstream), "config", "user.name", "Test"], check=True)
     subprocess.run(["git", "-C", str(upstream), "add", "."], check=True)
@@ -575,7 +587,11 @@ def test_update_lock_can_refresh_one_component_without_fetching_unrelated_source
     _write_skill(first_upstream / "skills", "first", "from first")
     _write_skill(second_upstream / "skills", "second", "from second")
     for upstream in (first_upstream, second_upstream):
-        subprocess.run(["git", "init", str(upstream)], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(
+            ["git", "init", "--initial-branch=master", str(upstream)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
         subprocess.run(["git", "-C", str(upstream), "config", "user.email", "test@example.com"], check=True)
         subprocess.run(["git", "-C", str(upstream), "config", "user.name", "Test"], check=True)
         subprocess.run(["git", "-C", str(upstream), "add", "."], check=True)


### PR DESCRIPTION
## Summary

Make the agent component Git fixture tests independent of the user's global Git default-branch configuration.

Several test fixtures referenced `master` in their component manifests, while temporary repositories were initialized without explicitly selecting a branch. On systems configured with `init.defaultBranch=main`, these tests failed because the expected `master` ref did not exist.

## Related issue

N/A

## Changes

- Initialize affected temporary Git repositories with `git init --initial-branch=master`.
- Keep the fixture repository branch consistent with the existing `ref: master` test manifests.
- Preserve the separate tag-based fixture behavior unchanged.
- Prevent the tests from depending on the contributor's global `init.defaultBranch` setting.

## Testing

- Ran the focused agent component contract tests on Windows:
  - `20 passed`
- Ran the complete contract test suite on Windows:
  - `1214 passed, 1 deselected`
- The deselected test is the expected HyperFrames-marked test excluded by the repository's default pytest configuration.
- Verified the branch is clean and contains only the intended test fixture changes.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] No unrelated files (build artifacts, local config) are included in the diff.