### PR TITLE
fix(paths): normalize project output paths across platforms

### DIFF
--- a/tests/tools/test_audio_mixer_volume_schedule.py
+++ b/tests/tools/test_audio_mixer_volume_schedule.py
@@ -191,7 +191,7 @@ def test_duck_schedule_filter_includes_input_paths_and_output(
     })
     assert str(speech) in cmd
     assert str(music) in cmd
-    assert out in cmd
+    assert str(Path(out)) in cmd
 
 
 def test_duck_schedule_emits_amix_to_combine_speech_and_ducked_music(

--- a/tests/tools/test_audio_providers.py
+++ b/tests/tools/test_audio_providers.py
@@ -447,9 +447,9 @@ def test_piper_tts_writes_to_validated_output_path(
     assert result.success is True
     assert (tmp_path / validated_output_path).read_bytes() == b"wav"
     assert not (tmp_path / raw_output_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.artifacts == [str(validated_output_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.artifacts == [validated_output_path.as_posix()]
 
 
 def test_google_tts_writes_to_validated_output_path(
@@ -494,9 +494,9 @@ def test_google_tts_writes_to_validated_output_path(
     assert result.success is True
     assert (tmp_path / validated_output_path).read_bytes() == b"mp3"
     assert not (tmp_path / raw_output_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.artifacts == [str(validated_output_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.artifacts == [validated_output_path.as_posix()]
 
 
 def test_music_gen_writes_to_validated_output_path(
@@ -540,9 +540,9 @@ def test_music_gen_writes_to_validated_output_path(
     assert result.success is True
     assert (tmp_path / validated_output_path).read_bytes() == b"mp3"
     assert not (tmp_path / raw_output_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.artifacts == [str(validated_output_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.artifacts == [validated_output_path.as_posix()]
 
 
 def test_minimax_music_writes_to_validated_output_path(
@@ -591,9 +591,9 @@ def test_minimax_music_writes_to_validated_output_path(
     assert result.success is True
     assert (tmp_path / validated_output_path).read_bytes() == b"mp3"
     assert not (tmp_path / raw_output_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.artifacts == [str(validated_output_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.artifacts == [validated_output_path.as_posix()]
 
 
 def test_suno_music_writes_to_validated_output_path(
@@ -652,9 +652,9 @@ def test_suno_music_writes_to_validated_output_path(
     assert result.success is True
     assert (tmp_path / validated_output_path).read_bytes() == b"mp3"
     assert not (tmp_path / raw_output_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.artifacts == [str(validated_output_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.artifacts == [validated_output_path.as_posix()]
 
 
 @pytest.mark.parametrize(
@@ -723,9 +723,9 @@ def test_cosyvoice_tts_writes_to_validated_output_path(
     assert result.success is True
     assert (tmp_path / validated_output_path).read_bytes() == b"mp3"
     assert not (tmp_path / raw_output_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.artifacts == [str(validated_output_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.artifacts == [validated_output_path.as_posix()]
 
 
 def test_doubao_tts_writes_to_validated_output_and_metadata_paths(
@@ -804,10 +804,13 @@ def test_doubao_tts_writes_to_validated_output_and_metadata_paths(
     assert (tmp_path / validated_metadata_path).read_text(encoding="utf-8")
     assert not (tmp_path / raw_output_path).exists()
     assert not (tmp_path / raw_metadata_path).exists()
-    assert result.data["output"] == str(validated_output_path)
-    assert result.data["output_path"] == str(validated_output_path)
-    assert result.data["metadata_path"] == str(validated_metadata_path)
-    assert result.artifacts == [str(validated_output_path), str(validated_metadata_path)]
+    assert result.data["output"] == validated_output_path.as_posix()
+    assert result.data["output_path"] == validated_output_path.as_posix()
+    assert result.data["metadata_path"] == validated_metadata_path.as_posix()
+    assert result.artifacts == [
+        validated_output_path.as_posix(),
+        validated_metadata_path.as_posix(),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1023,7 +1026,7 @@ def test_generated_media_output_path_accepts_project_assets_path():
     )
 
     assert error is None
-    assert str(returned_path) == "projects/demo/assets/audio/voice.mp3"
+    assert returned_path.as_posix() == "projects/demo/assets/audio/voice.mp3"
 
 
 def test_audio_mixer_mix_success_payload_matches_output_schema(

--- a/tests/tools/test_base_tool_dependencies.py
+++ b/tests/tools/test_base_tool_dependencies.py
@@ -851,6 +851,58 @@ def test_tool_result_to_dict_is_json_safe_for_path_values():
     json.dumps(payload, allow_nan=False)
 
 
+def test_tool_result_normalizes_project_path_strings_at_output_boundary():
+    result = ToolResult(
+        success=True,
+        data={
+            "output_path": r"projects\demo\renders\final.mp4",
+            "nested": [r"projects\demo\artifacts\report.json"],
+            "absolute_project_path": (
+                r"C:\workspace\projects\demo\renders\final.mp4"
+            ),
+            "input_path": r"C:\source\input.mp4",
+            "message": r"keep\arbitrary\text",
+        },
+        artifacts=[r"projects\demo\renders\final.mp4"],
+    )
+
+    assert result.data == {
+        "output_path": "projects/demo/renders/final.mp4",
+        "nested": ["projects/demo/artifacts/report.json"],
+        "absolute_project_path": (
+            "C:/workspace/projects/demo/renders/final.mp4"
+        ),
+        "input_path": r"C:\source\input.mp4",
+        "message": r"keep\arbitrary\text",
+    }
+    assert result.artifacts == ["projects/demo/renders/final.mp4"]
+
+
+def test_tool_result_normalizes_project_paths_embedded_in_errors():
+    result = ToolResult(
+        success=False,
+        error=r"Expected output was not created: projects\demo\renders\final.mp4",
+    )
+
+    assert result.error == (
+        "Expected output was not created: projects/demo/renders/final.mp4"
+    )
+
+
+def test_base_tool_normalizes_project_references_added_after_result_creation():
+    class MutatingResultTool(BaseTool):
+        def execute(self, inputs: dict[str, Any]) -> ToolResult:
+            result = ToolResult(success=True)
+            result.data["output_path"] = r"projects\demo\renders\final.mp4"
+            result.artifacts.append(r"projects\demo\renders\final.mp4")
+            return result
+
+    result = MutatingResultTool().execute({})
+
+    assert result.data["output_path"] == "projects/demo/renders/final.mp4"
+    assert result.artifacts == ["projects/demo/renders/final.mp4"]
+
+
 def test_tool_result_to_dict_replaces_non_finite_numbers_with_nulls():
     result = ToolResult(
         success=True,

--- a/tests/tools/test_edge_media_tools.py
+++ b/tests/tools/test_edge_media_tools.py
@@ -55,7 +55,7 @@ def test_cap_pick_latest_accepts_exact_output_file_path(tmp_path, monkeypatch):
     )
 
     assert result.success
-    assert result.data["output_path"] == str(requested_output)
+    assert result.data["output_path"] == requested_output.as_posix()
     assert (tmp_path / requested_output).read_bytes() == b"cap-recording"
 
 

--- a/tests/tools/test_hyperframes_compose.py
+++ b/tests/tools/test_hyperframes_compose.py
@@ -1471,11 +1471,11 @@ def test_hyperframes_render_success_payload_includes_output_path(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output"] == str(output_path)
-    assert result.data["output_path"] == str(output_path)
-    assert result.data["workspace"] == str(workspace_path.resolve())
-    assert result.data["workspace_path"] == str(workspace_path.resolve())
-    assert result.artifacts == [str(output_path)]
+    assert result.data["output"] == output_path.as_posix()
+    assert result.data["output_path"] == output_path.as_posix()
+    assert result.data["workspace"] == workspace_path.resolve().as_posix()
+    assert result.data["workspace_path"] == workspace_path.resolve().as_posix()
+    assert result.artifacts == [output_path.as_posix()]
     assert {
         "operation",
         "output",
@@ -1570,10 +1570,12 @@ def test_hyperframes_render_passes_absolute_output_path_to_cli(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output_path"] == str(output_path)
+    assert result.data["output_path"] == output_path.as_posix()
     render_step = result.data["steps"]["render"]
     assert Path(render_step["cli_output_path"]).is_absolute()
-    assert render_step["cli_output_path"] == str(output_path.resolve(strict=False))
+    assert render_step["cli_output_path"] == output_path.resolve(
+        strict=False
+    ).as_posix()
     assert output_path.read_bytes() == b"rendered"
 
 
@@ -1631,7 +1633,7 @@ def test_hyperframes_render_missing_output_error_names_cli_output_path(
     )
 
     assert result.success is False
-    expected_cli_path = str(output_path.resolve(strict=False))
+    expected_cli_path = output_path.resolve(strict=False).as_posix()
     assert expected_cli_path in (result.error or "")
     assert "stdout_tail" not in (result.error or "")
     assert result.data is not None
@@ -1673,12 +1675,12 @@ def test_hyperframes_scaffold_packages_cjk_font_for_chinese_text(tmp_path: Path)
     assert "Noto Sans SC" in html
     assert "assets/NotoSansSC.ttf" in html
     assert result.data is not None
-    assert result.data["workspace"] == str(workspace_path)
-    assert result.data["workspace_path"] == str(workspace_path)
+    assert result.data["workspace"] == workspace_path.as_posix()
+    assert result.data["workspace_path"] == workspace_path.as_posix()
     font_assets = result.data["font_assets"]
     assert font_assets[0]["family"] == "Noto Sans SC"
-    assert font_assets[0]["from"] == str(font_path)
-    assert font_assets[0]["to"] == str(staged_font)
+    assert font_assets[0]["from"] == font_path.as_posix()
+    assert font_assets[0]["to"] == staged_font.as_posix()
     assert font_assets[0]["src"] == "assets/NotoSansSC.ttf"
     assert font_assets[0]["format"] == "truetype"
     jsonschema.validate(instance=result.data, schema=HyperFramesCompose.output_schema)

--- a/tests/tools/test_local_utility_tools.py
+++ b/tests/tools/test_local_utility_tools.py
@@ -11,7 +11,7 @@ import pytest
 import jsonschema
 
 from tools.audio.audio_mixer import AudioMixer
-from tools.base_tool import ToolStatus
+from tools.base_tool import ToolResult, ToolStatus
 from tools.capture.cap_recorder import CapRecorder
 from tools.capture.screen_recorder import ScreenRecorder
 from tools.capture.screen_capture_selector import ScreenCaptureSelector
@@ -197,9 +197,13 @@ def test_cap_recorder_pick_latest_copies_to_project_destination(
     copied = tmp_path / "projects/test-screen-demo/renders/cap/recording.mp4"
     assert result.success is True
     assert copied.read_bytes() == b"cap-video"
-    assert result.data["output_dir"] == str(Path("projects/test-screen-demo/renders/cap"))
-    assert result.data["output_path"] == str(Path("projects/test-screen-demo/renders/cap/recording.mp4"))
-    assert result.artifacts == [str(Path("projects/test-screen-demo/renders/cap/recording.mp4"))]
+    assert result.data["output_dir"] == "projects/test-screen-demo/renders/cap"
+    assert result.data["output_path"] == (
+        "projects/test-screen-demo/renders/cap/recording.mp4"
+    )
+    assert result.artifacts == [
+        "projects/test-screen-demo/renders/cap/recording.mp4"
+    ]
 
 
 def test_cap_recorder_pick_latest_honors_since_minutes(
@@ -1520,7 +1524,7 @@ def test_diagram_gen_mermaid_cli_fails_when_expected_output_is_missing(
     )
 
     assert result.success is False
-    assert str(output_path) in (result.error or "")
+    assert output_path.as_posix() in (result.error or "")
 
 
 def test_diagram_gen_rejects_non_finite_mermaid_config_before_render(
@@ -1777,7 +1781,7 @@ def test_screen_capture_selector_record_passes_valid_project_output_to_ffmpeg(
 
         def execute(self, provider_inputs: dict[str, object]) -> Any:
             calls.append(provider_inputs)
-            return SimpleNamespace(
+            return ToolResult(
                 success=True,
                 data={"output_path": provider_inputs["output_path"]},
                 artifacts=[provider_inputs["output_path"]],
@@ -1803,7 +1807,9 @@ def test_screen_capture_selector_record_passes_valid_project_output_to_ffmpeg(
     assert result.success is True
     assert calls == [
         {
-            "output_path": "projects/test-screen-demo/renders/recording.mp4",
+            "output_path": str(
+                Path("projects/test-screen-demo/renders/recording.mp4")
+            ),
             "duration_seconds": 5,
             "fps": 24,
             "capture_audio": False,
@@ -1854,7 +1860,7 @@ def test_screen_capture_selector_pick_latest_copies_cap_recording_to_project_out
         def execute(self, provider_inputs: dict[str, object]) -> Any:
             calls.append(provider_inputs)
             if provider_inputs["operation"] == "pick_latest":
-                return SimpleNamespace(
+                return ToolResult(
                     success=True,
                     data={
                         "output_path": provider_inputs["output_dir"],
@@ -1862,7 +1868,7 @@ def test_screen_capture_selector_pick_latest_copies_cap_recording_to_project_out
                     },
                     artifacts=[provider_inputs["output_dir"]],
                 )
-            return SimpleNamespace(
+            return ToolResult(
                 success=True,
                 data={
                     "recordings": [
@@ -1893,7 +1899,7 @@ def test_screen_capture_selector_pick_latest_copies_cap_recording_to_project_out
     assert calls == [
         {
             "operation": "pick_latest",
-            "output_dir": "projects/test-screen-demo/renders/latest.mp4",
+            "output_dir": str(Path("projects/test-screen-demo/renders/latest.mp4")),
             "since_minutes": 9,
         }
     ]

--- a/tests/tools/test_output_paths.py
+++ b/tests/tools/test_output_paths.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import ast
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Callable
 
 import pytest
 
 from tools.base_tool import ToolResult
 from tools.output_paths import (
+    portable_output_path,
     require_explicit_output_path,
     require_explicit_project_artifact_destination,
     require_explicit_project_corpus_destination,
@@ -34,6 +35,26 @@ EXPLICIT_OUTPUT_HELPERS = {
     "require_explicit_project_source_media_destination",
     "require_explicit_project_corpus_destination",
 }
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (
+            PureWindowsPath("projects", "demo", "renders", "final.mp4"),
+            "projects/demo/renders/final.mp4",
+        ),
+        (
+            PureWindowsPath("C:/workspace/projects/demo/artifacts/report.json"),
+            "C:/workspace/projects/demo/artifacts/report.json",
+        ),
+    ],
+)
+def test_portable_output_path_normalizes_windows_separators(
+    path: PureWindowsPath,
+    expected: str,
+) -> None:
+    assert portable_output_path(path) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_video_compose_ffmpeg_timeline.py
+++ b/tests/tools/test_video_compose_ffmpeg_timeline.py
@@ -77,7 +77,7 @@ def test_ffmpeg_compose_uses_source_in_seconds_for_source_seek(
 
     assert result.success, result.error
     assert result.data is not None
-    assert result.data["output_path"] == str(output)
+    assert result.data["output_path"] == output.as_posix()
     trim_cmd = commands[0]
     assert trim_cmd[trim_cmd.index("-ss") + 1] == "1.25"
     assert trim_cmd[trim_cmd.index("-t") + 1] == "2.5"
@@ -215,7 +215,7 @@ def test_burn_subtitles_escapes_single_quotes_in_subtitle_filter(
 
     assert result.success, result.error
     assert result.data is not None
-    assert result.data["output_path"] == str(output_path)
+    assert result.data["output_path"] == output_path.as_posix()
     assert "subtitle\\'s" in captured["vf"]
 
 
@@ -532,9 +532,9 @@ def test_video_compose_remotion_render_success_payload_includes_output_path(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output"] == str(output)
-    assert result.data["output_path"] == str(output)
-    assert result.artifacts == [str(output)]
+    assert result.data["output"] == output.as_posix()
+    assert result.data["output_path"] == output.as_posix()
+    assert result.artifacts == [output.as_posix()]
     _assert_video_compose_output_schema_matches(
         result.data,
         {"operation", "output", "output_path", "profile"},
@@ -570,9 +570,9 @@ def test_video_compose_overlay_success_payload_includes_output_path(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output"] == str(output)
-    assert result.data["output_path"] == str(output)
-    assert result.artifacts == [str(output)]
+    assert result.data["output"] == output.as_posix()
+    assert result.data["output_path"] == output.as_posix()
+    assert result.artifacts == [output.as_posix()]
     _assert_video_compose_output_schema_matches(
         result.data,
         {"operation", "overlay_count", "output", "output_path"},
@@ -605,9 +605,9 @@ def test_video_compose_encode_success_payload_includes_output_path(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output"] == str(output)
-    assert result.data["output_path"] == str(output)
-    assert result.artifacts == [str(output)]
+    assert result.data["output"] == output.as_posix()
+    assert result.data["output_path"] == output.as_posix()
+    assert result.artifacts == [output.as_posix()]
     _assert_video_compose_output_schema_matches(
         result.data,
         {"operation", "codec", "crf", "profile", "output", "output_path"},

--- a/tests/tools/test_video_stitch.py
+++ b/tests/tools/test_video_stitch.py
@@ -301,9 +301,9 @@ def test_video_stitch_success_payload_includes_output_path(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output"] == str(output_path)
-    assert result.data["output_path"] == str(output_path)
-    assert result.artifacts == [str(output_path)]
+    assert result.data["output"] == output_path.as_posix()
+    assert result.data["output_path"] == output_path.as_posix()
+    assert result.artifacts == [output_path.as_posix()]
     assert {
         "operation",
         "clip_count",
@@ -365,9 +365,9 @@ def test_video_stitch_spatial_success_payload_includes_output_path(
 
     assert result.success is True
     assert result.data is not None
-    assert result.data["output"] == str(output_path)
-    assert result.data["output_path"] == str(output_path)
-    assert result.artifacts == [str(output_path)]
+    assert result.data["output"] == output_path.as_posix()
+    assert result.data["output_path"] == output_path.as_posix()
+    assert result.artifacts == [output_path.as_posix()]
     jsonschema.validate(instance=result.data, schema=VideoStitch.output_schema)
 
 

--- a/tools/analysis/face_tracker.py
+++ b/tools/analysis/face_tracker.py
@@ -24,7 +24,7 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.output_paths import require_explicit_project_sidecar_path
+from tools.output_paths import portable_output_path, require_explicit_project_sidecar_path
 
 
 class FaceTracker(BaseTool):
@@ -187,8 +187,8 @@ class FaceTracker(BaseTool):
         return ToolResult(
             success=True,
             data={
-                "output": str(output_path),
-                "output_path": str(output_path),
+                "output": portable_output_path(output_path),
+                "output_path": portable_output_path(output_path),
                 "video_width": result_data["video_width"],
                 "video_height": result_data["video_height"],
                 "fps": result_data["fps"],
@@ -197,7 +197,7 @@ class FaceTracker(BaseTool):
                 "faces_detected": result_data["face_detected_count"],
                 "method": "mediapipe" if self._has_mediapipe() else "opencv_haar",
             },
-            artifacts=[str(output_path)],
+            artifacts=[portable_output_path(output_path)],
             duration_seconds=round(elapsed, 2),
         )
 

--- a/tools/analysis/frame_sampler.py
+++ b/tools/analysis/frame_sampler.py
@@ -22,7 +22,10 @@ from tools.base_tool import (
     ToolStability,
     ToolTier,
 )
-from tools.output_paths import require_explicit_project_media_directory_destination
+from tools.output_paths import (
+    portable_output_path,
+    require_explicit_project_media_directory_destination,
+)
 
 
 STRATEGIES = ["interval", "count", "timestamps", "scene_guided"]
@@ -191,9 +194,9 @@ class FrameSampler(BaseTool):
                 "strategy": strategy,
                 "frame_count": len(frames),
                 "frames": frames,
-                "output_dir": str(output_dir),
+                "output_dir": portable_output_path(output_dir),
             },
-            artifacts=[str(output_dir)],
+            artifacts=[portable_output_path(output_dir)],
             duration_seconds=round(elapsed, 2),
         )
 
@@ -278,7 +281,7 @@ class FrameSampler(BaseTool):
 
             if output_file.exists():
                 frames.append({
-                    "path": str(output_file),
+                    "path": portable_output_path(output_file),
                     "timestamp_seconds": ts,
                     "index": i,
                 })
@@ -354,7 +357,7 @@ class FrameSampler(BaseTool):
         pattern = f"frame_*.{fmt}"
         for i, path in enumerate(sorted(output_dir.glob(pattern))):
             frames.append({
-                "path": str(path),
+                "path": portable_output_path(path),
                 "timestamp_seconds": round(i * interval, 3),
                 "index": i,
             })

--- a/tools/analysis/qwen_vl.py
+++ b/tools/analysis/qwen_vl.py
@@ -33,7 +33,7 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.output_paths import require_optional_project_sidecar_path
+from tools.output_paths import portable_output_path, require_optional_project_sidecar_path
 
 _CHAT_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
 
@@ -245,7 +245,7 @@ class QwenVL(BaseTool):
         if output_path is not None:
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(text, encoding="utf-8")
-            out_str = str(output_path)
+            out_str = portable_output_path(output_path)
 
         usage = data.get("usage", {})
         return ToolResult(

--- a/tools/analysis/scene_detect.py
+++ b/tools/analysis/scene_detect.py
@@ -21,7 +21,7 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.output_paths import require_explicit_project_sidecar_path
+from tools.output_paths import portable_output_path, require_explicit_project_sidecar_path
 
 
 METHODS = ["content", "threshold", "adaptive"]
@@ -171,10 +171,10 @@ class SceneDetect(BaseTool):
                 "scene_count": len(scenes),
                 "scenes": scenes,
                 "method": "pyscenedetect" if self._has_pyscenedetect() else "ffmpeg",
-                "output": str(output_path),
-                "output_path": str(output_path),
+                "output": portable_output_path(output_path),
+                "output_path": portable_output_path(output_path),
             },
-            artifacts=[str(output_path)],
+            artifacts=[portable_output_path(output_path)],
             duration_seconds=round(elapsed, 2),
         )
 

--- a/tools/analysis/transcriber.py
+++ b/tools/analysis/transcriber.py
@@ -24,7 +24,10 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.output_paths import require_explicit_project_sidecar_destination
+from tools.output_paths import (
+    portable_output_path,
+    require_explicit_project_sidecar_destination,
+)
 
 
 MODEL_SIZES = ["tiny", "base", "small", "medium", "large-v2", "large-v3"]
@@ -271,8 +274,8 @@ class Transcriber(BaseTool):
         output_path = output_dir / f"{input_path.stem}_transcript.json"
 
         result_data = {
-            "output_dir": str(output_dir),
-            "transcript_path": str(output_path),
+            "output_dir": portable_output_path(output_dir),
+            "transcript_path": portable_output_path(output_path),
             "segments": segments,
             "word_timestamps": word_timestamps,
             "language": detected_language,
@@ -294,7 +297,7 @@ class Transcriber(BaseTool):
         return ToolResult(
             success=True,
             data=result_data,
-            artifacts=[str(output_path)],
+            artifacts=[portable_output_path(output_path)],
             duration_seconds=round(elapsed, 2),
         )
 

--- a/tools/analysis/video_analyzer.py
+++ b/tools/analysis/video_analyzer.py
@@ -27,7 +27,10 @@ from tools.base_tool import (
     ToolTier,
     ToolRuntime,
 )
-from tools.output_paths import require_explicit_project_artifact_destination
+from tools.output_paths import (
+    portable_output_path,
+    require_explicit_project_artifact_destination,
+)
 
 
 ANALYSIS_DEPTHS = ["transcript_only", "standard", "deep"]
@@ -246,7 +249,7 @@ class VideoAnalyzer(BaseTool):
         # Initialize brief structure
         brief = {
             "version": "1.0",
-            "output_dir": str(output_dir),
+            "output_dir": portable_output_path(output_dir),
             "source": {
                 "type": platform,
                 "duration_seconds": 0,
@@ -458,7 +461,9 @@ class VideoAnalyzer(BaseTool):
             return ToolResult(
                 success=True,
                 data=brief,
-                artifacts=[str(output_dir / "video_analysis_brief.json")],
+                artifacts=[
+                    portable_output_path(output_dir / "video_analysis_brief.json")
+                ],
                 duration_seconds=round(time.time() - start, 2),
             )
 
@@ -657,9 +662,9 @@ class VideoAnalyzer(BaseTool):
         self._save_brief(brief, output_dir)
 
         elapsed = time.time() - start
-        artifacts = [str(output_dir / "video_analysis_brief.json")]
+        artifacts = [portable_output_path(output_dir / "video_analysis_brief.json")]
         if keyframe_dir.exists():
-            artifacts.append(str(keyframe_dir))
+            artifacts.append(portable_output_path(keyframe_dir))
 
         return ToolResult(
             success=True,

--- a/tools/analysis/video_downloader.py
+++ b/tools/analysis/video_downloader.py
@@ -24,7 +24,10 @@ from tools.base_tool import (
     ToolTier,
     ToolRuntime,
 )
-from tools.output_paths import require_explicit_project_source_media_destination
+from tools.output_paths import (
+    portable_output_path,
+    require_explicit_project_source_media_destination,
+)
 
 
 FORMATS = ["video", "audio_only", "subtitles_only", "metadata_only"]
@@ -261,7 +264,7 @@ class VideoDownloader(BaseTool):
                     "subtitle_path": None,
                     "metadata": metadata,
                     "platform": platform,
-                    "output_dir": str(output_dir),
+                    "output_dir": portable_output_path(output_dir),
                 },
                 duration_seconds=round(time.time() - start, 2),
             )
@@ -289,17 +292,34 @@ class VideoDownloader(BaseTool):
             )
 
         elapsed = time.time() - start
-        artifacts = [p for p in [video_path, audio_path, subtitle_path] if p]
+        portable_video_path = (
+            portable_output_path(Path(video_path)) if video_path else None
+        )
+        portable_audio_path = (
+            portable_output_path(Path(audio_path)) if audio_path else None
+        )
+        portable_subtitle_path = (
+            portable_output_path(Path(subtitle_path)) if subtitle_path else None
+        )
+        artifacts = [
+            path
+            for path in [
+                portable_video_path,
+                portable_audio_path,
+                portable_subtitle_path,
+            ]
+            if path
+        ]
 
         return ToolResult(
             success=True,
             data={
-                "video_path": video_path,
-                "audio_path": audio_path,
-                "subtitle_path": subtitle_path,
+                "video_path": portable_video_path,
+                "audio_path": portable_audio_path,
+                "subtitle_path": portable_subtitle_path,
                 "metadata": metadata,
                 "platform": platform,
-                "output_dir": str(output_dir),
+                "output_dir": portable_output_path(output_dir),
             },
             artifacts=artifacts,
             duration_seconds=round(elapsed, 2),

--- a/tools/analysis/visual_qa.py
+++ b/tools/analysis/visual_qa.py
@@ -24,7 +24,10 @@ from tools.base_tool import (
     ToolStability,
     ToolTier,
 )
-from tools.output_paths import require_explicit_project_media_directory_destination
+from tools.output_paths import (
+    portable_output_path,
+    require_explicit_project_media_directory_destination,
+)
 
 
 class VisualQA(BaseTool):
@@ -276,21 +279,21 @@ class VisualQA(BaseTool):
         frames = []
         for ts in timestamps:
             ts_label = f"{ts:.1f}".replace(".", "_")
-            frame_path = str(output_dir / f"frame_{ts_label}s.jpg")
+            frame_path = output_dir / f"frame_{ts_label}s.jpg"
             cmd = [
                 "ffmpeg", "-y",
                 "-ss", str(ts),
                 "-i", input_path,
                 "-frames:v", "1",
                 "-q:v", "2",
-                frame_path,
+                str(frame_path),
             ]
             try:
                 self.run_command(cmd)
-                if Path(frame_path).exists():
+                if frame_path.exists():
                     frames.append({
                         "timestamp": ts,
-                        "path": frame_path,
+                        "path": portable_output_path(frame_path),
                     })
             except Exception:
                 frames.append({
@@ -304,7 +307,7 @@ class VisualQA(BaseTool):
             data={
                 "operation": "review",
                 "input": input_path,
-                "output_dir": str(output_dir),
+                "output_dir": portable_output_path(output_dir),
                 "frame_count": len([f for f in frames if f.get("path")]),
                 "frames": frames,
             },

--- a/tools/base_tool.py
+++ b/tools/base_tool.py
@@ -170,6 +170,29 @@ def _json_safe(value: Any) -> Any:
     return str(value)
 
 
+def _portable_project_references(value: Any) -> Any:
+    """Normalize project-scoped path strings at the ToolResult boundary.
+
+    Tool implementations keep native paths for filesystem and subprocess work.
+    Once a project-relative path is returned as metadata, forward slashes keep
+    the reference stable across operating systems without rewriting arbitrary
+    user text, URLs, or absolute input paths.
+    """
+    if isinstance(value, str):
+        normalized = value.replace("\\", "/")
+        return normalized if "projects/" in normalized else value
+    if isinstance(value, dict):
+        return {
+            key: _portable_project_references(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_portable_project_references(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_portable_project_references(item) for item in value)
+    return value
+
+
 @dataclass
 class ToolResult:
     """Standard result returned by tool execution."""
@@ -181,6 +204,15 @@ class ToolResult:
     duration_seconds: float = 0.0
     seed: Optional[int] = None
     model: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.normalize_project_references()
+
+    def normalize_project_references(self) -> None:
+        """Normalize persisted project references after result mutations."""
+        self.data = _portable_project_references(self.data)
+        self.artifacts = _portable_project_references(self.artifacts)
+        self.error = _portable_project_references(self.error)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-safe snapshot for checkpoint/report persistence."""
@@ -252,6 +284,9 @@ def _instrument_execute(fn: Callable) -> Callable:
             raise
         finally:
             depth_state.value = depth
+
+        if isinstance(result, ToolResult):
+            result.normalize_project_references()
 
         if project_dir is None:
             # The tool may have created its own project dir during execute

--- a/tools/output_paths.py
+++ b/tools/output_paths.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from os import PathLike, fspath
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 from tools.base_tool import ToolResult
@@ -13,6 +13,16 @@ _PROJECT_ARTIFACT_ROOTS = {"artifacts"}
 _PROJECT_SIDECAR_ROOTS = {"artifacts", "assets", "renders"}
 _SOURCE_MEDIA_ROOTS = {"assets", "reference_assets"}
 _PROJECT_CORPUS_ROOTS = {"corpus"}
+
+
+def portable_output_path(path: PurePath) -> str:
+    """Serialize a filesystem path for persisted tool output metadata.
+
+    Tools should keep using native ``Path`` objects for filesystem and subprocess
+    operations. At JSON, artifact, and ``ToolResult`` boundaries, POSIX-style
+    separators keep project-relative references stable across operating systems.
+    """
+    return path.as_posix()
 
 
 def require_explicit_output_path(

--- a/tools/video/video_trimmer.py
+++ b/tools/video/video_trimmer.py
@@ -23,7 +23,7 @@ from tools.base_tool import (
     ToolStability,
     ToolTier,
 )
-from tools.output_paths import require_explicit_output_path
+from tools.output_paths import portable_output_path, require_explicit_output_path
 
 
 def _ffconcat_quote(path: str) -> str:
@@ -188,17 +188,19 @@ class VideoTrimmer(BaseTool):
 
         self.run_command(cmd)
 
+        output_ref = portable_output_path(output_path)
+
         return ToolResult(
             success=True,
             data={
                 "operation": "cut",
                 "input": str(input_path),
-                "output": str(output_path),
-                "output_path": str(output_path),
+                "output": output_ref,
+                "output_path": output_ref,
                 "start_seconds": start_s,
                 "end_seconds": end_s,
             },
-            artifacts=[str(output_path)],
+            artifacts=[output_ref],
         )
 
     def _speed(self, inputs: dict[str, Any]) -> ToolResult:
@@ -234,16 +236,18 @@ class VideoTrimmer(BaseTool):
 
         self.run_command(cmd)
 
+        output_ref = portable_output_path(output_path)
+
         return ToolResult(
             success=True,
             data={
                 "operation": "speed",
                 "input": str(input_path),
-                "output": str(output_path),
-                "output_path": str(output_path),
+                "output": output_ref,
+                "output_path": output_ref,
                 "speed_factor": factor,
             },
-            artifacts=[str(output_path)],
+            artifacts=[output_ref],
         )
 
     def _concat(self, inputs: dict[str, Any]) -> ToolResult:
@@ -305,15 +309,17 @@ class VideoTrimmer(BaseTool):
             ]
             self.run_command(cmd)
 
+            output_ref = portable_output_path(output_path)
+
             return ToolResult(
                 success=True,
                 data={
                     "operation": "concat",
                     "segment_count": len(segments),
-                    "output": str(output_path),
-                    "output_path": str(output_path),
+                    "output": output_ref,
+                    "output_path": output_ref,
                 },
-                artifacts=[str(output_path)],
+                artifacts=[output_ref],
             )
         finally:
             # Clean up temp segment files (but not the originals)


### PR DESCRIPTION
## Summary

Normalize project-scoped output paths across analysis, video, and shared tool
results so persisted references remain consistent on Windows and POSIX systems.

Tools continue to use native paths for filesystem access and subprocess
execution, while returned `projects/...` references use portable forward
slashes.

## Related issue

N/A

## Changes

- Normalize output paths returned by analysis tools, including frame sampling,
  scene detection, transcription, downloading, visual QA, and related outputs.
- Normalize `VideoTrimmer` output paths and artifacts.
- Add shared normalization at the `ToolResult` boundary for nested data,
  artifacts, and project paths embedded in errors.
- Re-normalize results after tool execution to cover tools that mutate their
  result after construction.
- Preserve native Windows paths for filesystem and subprocess operations.
- Preserve external absolute input paths, URLs, and unrelated text.
- Update audio, capture, HyperFrames, video compose, video stitch, and base tool
  tests to distinguish native execution paths from persisted project references.
- Add regression tests for Windows relative and absolute project paths.

## Testing

- Affected tool tests: `589 passed, 13 deselected`
- Contract tests: `1216 passed, 1 deselected`
- Backlot, pipeline, style, and eval tests: `39 passed, 1 skipped`
- Repository hygiene contracts: `8 passed`
- `git diff --check`

The deselected tests require optional runtimes or environments such as FFmpeg,
Node.js, HyperFrames, browsers, integration services, or live providers. No
paid provider APIs were called.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally.
- [x] No documentation change is required; the implementation now follows the
      existing portable output-path contract.
- [x] No unrelated files, generated media, build artifacts, or local
      configuration files are included.