### PR TITLE
feat: add MuAPI video provider

### DIFF
--- a/tests/tools/test_cloud_video_providers.py
+++ b/tests/tools/test_cloud_video_providers.py
@@ -12,6 +12,7 @@ from tools.video.higgsfield_video import HiggsFieldVideo
 from tools.video.kling_video import KlingVideo
 from tools.video.ltx_video_modal import LTXVideoModal
 from tools.video.minimax_video import MiniMaxVideo
+from tools.video.muapi_video import MuapiVideo
 from tools.video.pexels_video import PexelsVideo
 from tools.video.pixabay_video import PixabayVideo
 from tools.video.runway_video import RunwayVideo
@@ -32,6 +33,7 @@ def _configure_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HEYGEN_API_KEY", "test-heygen-key")
     monkeypatch.setenv("MODAL_LTX2_ENDPOINT_URL", "https://modal.example.test/ltx")
     monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
+    monkeypatch.setenv("MUAPI_API_KEY", "test-muapi-key")
 
 
 def _fail_network(*_args, **_kwargs):
@@ -43,6 +45,7 @@ def _fail_network(*_args, **_kwargs):
     [
         KlingVideo(),
         AtlasCloudVideo(),
+        MuapiVideo(),
         MiniMaxVideo(),
         RunwayVideo(),
         HiggsFieldVideo(),
@@ -70,6 +73,7 @@ def test_cloud_video_image_to_video_requires_image_before_network(
     [
         KlingVideo(),
         AtlasCloudVideo(),
+        MuapiVideo(),
         MiniMaxVideo(),
         RunwayVideo(),
         HiggsFieldVideo(),
@@ -123,6 +127,7 @@ def test_minimax_fast_rejects_text_to_video_before_network(
     [
         KlingVideo(),
         AtlasCloudVideo(),
+        MuapiVideo(),
         MiniMaxVideo(),
         RunwayVideo(),
         HiggsFieldVideo(),
@@ -175,6 +180,7 @@ def test_cloud_video_requires_project_output_path_before_network(
     [
         (GrokVideo(), ("XAI_API_KEY",)),
         (AtlasCloudVideo(), ("ATLASCLOUD_API_KEY",)),
+        (MuapiVideo(), ("MUAPI_API_KEY", "MU_API_KEY")),
         (HeyGenVideo(), ("HEYGEN_API_KEY",)),
         (KlingVideo(), ("FAL_KEY", "FAL_AI_API_KEY")),
         (MiniMaxVideo(), ("MINIMAX_API_KEY",)),
@@ -212,6 +218,7 @@ def test_cloud_video_rejects_non_project_output_path_before_credentials(
     [
         (GrokVideo(), {"prompt": "A product hero shot"}),
         (AtlasCloudVideo(), {"prompt": "A product hero shot"}),
+        (MuapiVideo(), {"prompt": "A product hero shot"}),
         (HeyGenVideo(), {"prompt": "A product hero shot"}),
         (HiggsFieldVideo(), {"prompt": "A product hero shot"}),
         (KlingVideo(), {"prompt": "A product hero shot"}),
@@ -692,6 +699,7 @@ def test_video_selector_uses_grok_reference_default_when_env_t2v_model_conflicts
         (SeedanceReplicate(), "image_url"),
         (VeoVideo(), "image_url"),
         (GrokVideo(), "image_url"),
+        (MuapiVideo(), "image_url"),
         (HeyGenVideo(), "reference_image_url"),
         (LTXVideoModal(), "reference_image_url"),
     ],

--- a/tests/tools/test_muapi_video.py
+++ b/tests/tools/test_muapi_video.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import jsonschema
+import pytest
+
+from tools.base_tool import ToolResult
+from tools.video.muapi_video import MuapiVideo
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        payload: dict | None = None,
+        content: bytes = b"fake mp4",
+        status_code: int = 200,
+    ) -> None:
+        self._payload = payload or {}
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _fail_network(*_args, **_kwargs):
+    raise AssertionError("network called before local input validation")
+
+
+def test_muapi_video_declares_video_contract() -> None:
+    tool = MuapiVideo()
+
+    assert tool.name == "muapi_video"
+    assert tool.provider == "muapi"
+    assert tool.agent_skills == ["ai-video-gen"]
+    assert tool.capabilities == ["text_to_video", "image_to_video"]
+
+
+def test_muapi_video_requires_project_output_path_before_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MUAPI_API_KEY", raising=False)
+    monkeypatch.delenv("MU_API_KEY", raising=False)
+    monkeypatch.setattr("requests.post", _fail_network)
+
+    result = MuapiVideo().execute(
+        {"prompt": "A product hero shot", "output_path": "muapi.mp4"}
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.success
+    assert "output_path" in (result.error or "")
+    assert "projects/<project-name>/" in (result.error or "")
+
+
+def test_muapi_video_image_to_video_requires_image_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MUAPI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", _fail_network)
+
+    result = MuapiVideo().execute(
+        {
+            "prompt": "Animate the product frame",
+            "operation": "image_to_video",
+            "output_path": "projects/demo/assets/video/muapi.mp4",
+        }
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.success
+    assert "image_to_video requires image_url" in (result.error or "")
+
+
+def test_muapi_video_rejects_mismatched_model_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MUAPI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", _fail_network)
+
+    result = MuapiVideo().execute(
+        {
+            "prompt": "A product hero shot",
+            "model_variant": "seedance-2-image-to-video",
+            "output_path": "projects/demo/assets/video/muapi.mp4",
+        }
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.success
+    assert "supports image_to_video" in (result.error or "")
+
+
+def test_muapi_video_text_to_video_success_matches_api_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MUAPI_API_KEY", "test-key")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "tools.video.muapi_video.probe_output",
+        lambda _path: {"file_size_bytes": 8},
+    )
+    captured: dict[str, object] = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured["headers"] = kwargs["headers"]
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"request_id": "request-1", "status": "processing"})
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/predictions/request-1/result"):
+            assert kwargs["headers"]["x-api-key"] == "test-key"
+            return _FakeResponse(
+                {
+                    "status": "completed",
+                    "content": [{"video_url": {"url": "https://cdn.example.test/out.mp4"}}],
+                }
+            )
+        if url == "https://cdn.example.test/out.mp4":
+            assert kwargs["allow_redirects"] is False
+            return _FakeResponse(content=b"fake mp4")
+        raise AssertionError(f"unexpected GET {url}")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    output_path = "projects/demo/assets/video/muapi.mp4"
+    result = MuapiVideo().execute(
+        {
+            "prompt": "A product hero shot",
+            "duration": 8,
+            "aspect_ratio": "16:9",
+            "output_path": output_path,
+        }
+    )
+
+    assert result.success, result.error
+    assert captured["url"] == "https://api.muapi.ai/api/v1/seedance-2-text-to-video"
+    assert captured["headers"] == {
+        "x-api-key": "test-key",
+        "Content-Type": "application/json",
+    }
+    assert captured["json"] == {
+        "prompt": "A product hero shot",
+        "duration": 8,
+        "aspect_ratio": "16:9",
+    }
+    assert (tmp_path / output_path).read_bytes() == b"fake mp4"
+    assert result.data["prediction_id"] == "request-1"
+    assert result.data["output_path"] == output_path
+    jsonschema.validate(instance=result.data, schema=MuapiVideo().output_schema)
+
+
+def test_muapi_video_image_to_video_maps_single_image_to_images_list(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MU_API_KEY", "test-key")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "tools.video.muapi_video.probe_output",
+        lambda _path: {"file_size_bytes": 8},
+    )
+    captured: dict[str, object] = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": "request-2"}})
+
+    def fake_get(url, **_kwargs):
+        if url.endswith("/predictions/request-2/result"):
+            return _FakeResponse({"status": "completed", "output": {"video": "https://cdn.example.test/i2v.mp4"}})
+        if url == "https://cdn.example.test/i2v.mp4":
+            return _FakeResponse(content=b"fake i2v")
+        raise AssertionError(f"unexpected GET {url}")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    result = MuapiVideo().execute(
+        {
+            "prompt": "Animate the product frame",
+            "operation": "image_to_video",
+            "image_url": "https://example.test/product.png",
+            "output_path": "projects/demo/assets/video/muapi-i2v.mp4",
+        }
+    )
+
+    assert result.success, result.error
+    assert captured["url"] == "https://api.muapi.ai/api/v1/seedance-2-image-to-video"
+    assert captured["json"] == {
+        "prompt": "Animate the product frame",
+        "duration": 5,
+        "aspect_ratio": "16:9",
+        "images_list": ["https://example.test/product.png"],
+    }
+    assert (tmp_path / "projects/demo/assets/video/muapi-i2v.mp4").read_bytes() == b"fake i2v"
+
+
+def test_muapi_video_rejects_insecure_output_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MUAPI_API_KEY", "test-key")
+
+    def fake_post(_url, **_kwargs):
+        return _FakeResponse({"request_id": "request-3"})
+
+    def fake_get(url, **_kwargs):
+        if url.endswith("/predictions/request-3/result"):
+            return _FakeResponse({"status": "completed", "video_url": "http://example.test/out.mp4"})
+        raise AssertionError("insecure output URL must not be downloaded")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    result = MuapiVideo().execute(
+        {
+            "prompt": "A product hero shot",
+            "output_path": "projects/demo/assets/video/muapi.mp4",
+        }
+    )
+
+    assert not result.success
+    assert "non-HTTPS" in (result.error or "")
+    assert not (tmp_path / "projects/demo/assets/video/muapi.mp4").exists()
+
+
+def test_muapi_video_is_discovered_by_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MUAPI_API_KEY", "test-key")
+    from tools.tool_registry import registry
+
+    registry.clear()
+    registry.discover()
+
+    assert registry.get("muapi_video").get_status().value == "available"

--- a/tools/video/muapi_video.py
+++ b/tools/video/muapi_video.py
@@ -1,0 +1,439 @@
+"""MuAPI video generation through the hosted submit -> poll API."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import time
+from typing import Any
+from urllib.parse import urlsplit
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video._shared import (
+    probe_output,
+    require_generated_video_output_path,
+    validate_video_operation,
+)
+
+_DEFAULT_BASE_URL = "https://api.muapi.ai/api/v1"
+_TEXT_ENDPOINT = "seedance-2-text-to-video"
+_TEXT_FAST_ENDPOINT = "seedance-2-text-to-video-fast"
+_IMAGE_ENDPOINT = "seedance-2-image-to-video"
+_IMAGE_FAST_ENDPOINT = "seedance-2-image-to-video-fast"
+_OPERATIONS = {"text_to_video", "image_to_video"}
+_DEFAULT_ENDPOINTS = {
+    "text_to_video": _TEXT_ENDPOINT,
+    "image_to_video": _IMAGE_ENDPOINT,
+}
+_ENDPOINTS: dict[str, dict[str, Any]] = {
+    _TEXT_ENDPOINT: {
+        "operation": "text_to_video",
+        "name": "Seedance 2 Text-to-Video",
+        "speed": "medium",
+        "quality": "high",
+        "cost_per_second": 0.25,
+    },
+    _TEXT_FAST_ENDPOINT: {
+        "operation": "text_to_video",
+        "name": "Seedance 2 Fast Text-to-Video",
+        "speed": "fast",
+        "quality": "high",
+        "cost_per_second": 0.15,
+    },
+    _IMAGE_ENDPOINT: {
+        "operation": "image_to_video",
+        "name": "Seedance 2 Image-to-Video",
+        "speed": "medium",
+        "quality": "high",
+        "cost_per_second": 0.25,
+    },
+    _IMAGE_FAST_ENDPOINT: {
+        "operation": "image_to_video",
+        "name": "Seedance 2 Fast Image-to-Video",
+        "speed": "fast",
+        "quality": "high",
+        "cost_per_second": 0.15,
+    },
+}
+_ASPECT_RATIOS = ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_MODEL_SOURCE_URL = "https://muapi.ai/ai-video-api"
+
+
+def _api_key() -> str | None:
+    return os.environ.get("MUAPI_API_KEY") or os.environ.get("MU_API_KEY")
+
+
+def _base_url() -> str:
+    return os.environ.get("MUAPI_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
+
+
+def _prediction_id(payload: dict[str, Any]) -> str | None:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+    for key in ("request_id", "id", "prediction_id", "task_id"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _status_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    if isinstance(data, dict) and "status" in data:
+        return data
+    return payload
+
+
+def _collect_video_urls(value: Any) -> list[str]:
+    """Collect output URLs without walking request/input fields."""
+
+    if isinstance(value, str):
+        return [value] if value.startswith(("http://", "https://")) else []
+    if isinstance(value, list):
+        urls: list[str] = []
+        for item in value:
+            urls.extend(_collect_video_urls(item))
+        return urls
+    if not isinstance(value, dict):
+        return []
+
+    urls: list[str] = []
+    for key in ("video_url", "video", "output_url", "download_url", "url"):
+        if key in value:
+            urls.extend(_collect_video_urls(value[key]))
+    for key in ("content", "outputs", "output", "result", "results", "data", "output_data"):
+        if key in value:
+            urls.extend(_collect_video_urls(value[key]))
+    return urls
+
+
+def _safe_output_url(url: str) -> str:
+    parsed = urlsplit(url)
+    hostname = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not hostname:
+        raise ValueError("MuAPI returned a non-HTTPS output URL")
+    if parsed.username or parsed.password or parsed.port:
+        raise ValueError("MuAPI returned an output URL with credentials or a port")
+    if hostname in {"localhost", "localhost.localdomain"}:
+        raise ValueError("MuAPI returned a local output URL")
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is not None and (address.is_private or address.is_loopback or address.is_link_local):
+        raise ValueError("MuAPI returned a private output URL")
+    return url
+
+
+class MuapiVideo(BaseTool):
+    name = "muapi_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "muapi"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["env_any:MUAPI_API_KEY,MU_API_KEY"]
+    install_instructions = (
+        "Set MUAPI_API_KEY to your MuAPI API key (MU_API_KEY is also accepted).\n"
+        "  Get one at https://muapi.ai/keys and see https://muapi.ai/docs"
+    )
+    agent_skills = ["ai-video-gen"]
+
+    capabilities = ["text_to_video", "image_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "aspect_ratio": True,
+        "duration": True,
+        "native_audio": True,
+    }
+    best_for = [
+        "hosted video generation through one MuAPI key",
+        "Seedance 2 text-to-video and image-to-video workflows",
+        "projects that need an async submit, poll, and local-download lifecycle",
+    ]
+    not_good_for = ["offline generation", "long-form video rendering"]
+    fallback_tools = ["seedance_video", "wan_video_api", "kling_video"]
+    quality_score = 0.9
+    model_options = [
+        {
+            "id": endpoint,
+            "name": meta["name"],
+            "field": "model_variant",
+            "operation": meta["operation"],
+            "default_for_operations": [
+                operation
+                for operation, default_endpoint in _DEFAULT_ENDPOINTS.items()
+                if endpoint == default_endpoint
+            ],
+            "quality": meta["quality"],
+            "speed": meta["speed"],
+            "source_url": _MODEL_SOURCE_URL,
+        }
+        for endpoint, meta in _ENDPOINTS.items()
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt", "output_path"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": sorted(_OPERATIONS),
+                "default": "text_to_video",
+            },
+            "model_variant": {
+                "type": "string",
+                "enum": list(_ENDPOINTS),
+                "description": "MuAPI model endpoint. Omit to use the operation default.",
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 4,
+                "maximum": 15,
+                "default": 5,
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": _ASPECT_RATIOS,
+                "default": "16:9",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Start-frame image URL for image_to_video.",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "required": [
+            "provider",
+            "model",
+            "prompt",
+            "operation",
+            "duration",
+            "aspect_ratio",
+            "prediction_id",
+            "output",
+            "output_path",
+            "format",
+            "file_size_bytes",
+        ],
+        "properties": {
+            "provider": {"type": "string", "const": "muapi"},
+            "model": {"type": "string"},
+            "prompt": {"type": "string"},
+            "operation": {"type": "string", "enum": sorted(_OPERATIONS)},
+            "duration": {"type": "integer", "minimum": 4, "maximum": 15},
+            "aspect_ratio": {"type": "string", "enum": _ASPECT_RATIOS},
+            "prediction_id": {"type": "string"},
+            "output": {"type": "string"},
+            "output_path": {"type": "string"},
+            "format": {"type": "string", "const": "mp4"},
+            "file_size_bytes": {"type": "integer", "minimum": 0},
+            "duration_seconds": {"type": "number", "minimum": 0},
+            "file_size_mb": {"type": "number", "minimum": 0},
+            "video_width": {"type": "integer", "minimum": 0},
+            "video_height": {"type": "integer", "minimum": 0},
+            "video_codec": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = [
+        "prompt",
+        "output_path",
+        "model_variant",
+        "operation",
+        "duration",
+        "aspect_ratio",
+        "image_url",
+    ]
+    side_effects = ["writes video file to output_path", "calls MuAPI video API"]
+    user_visible_verification = [
+        "Inspect sampled frames for motion coherence and visual quality"
+    ]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if _api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        operation = inputs.get("operation", "text_to_video")
+        model = inputs.get("model_variant") or _DEFAULT_ENDPOINTS.get(operation, _TEXT_ENDPOINT)
+        spec = _ENDPOINTS.get(str(model), _ENDPOINTS[_TEXT_ENDPOINT])
+        try:
+            duration = int(inputs.get("duration", 5))
+        except (TypeError, ValueError):
+            duration = 5
+        return round(duration * float(spec["cost_per_second"]), 3)
+
+    def estimate_runtime(self, _inputs: dict[str, Any]) -> float:
+        return 120.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        operation = inputs.get("operation", "text_to_video")
+        operation_error = validate_video_operation(operation, _OPERATIONS)
+        if operation_error:
+            return ToolResult(success=False, error=operation_error)
+
+        model = inputs.get("model_variant") or _DEFAULT_ENDPOINTS[operation]
+        if model not in _ENDPOINTS:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Unknown model_variant {model!r}. "
+                    f"Available: {', '.join(_ENDPOINTS)}."
+                ),
+            )
+        model_operation = _ENDPOINTS[model]["operation"]
+        if model_operation != operation:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"model_variant {model!r} supports {model_operation}, "
+                    f"but operation is {operation}."
+                ),
+            )
+        if operation == "image_to_video" and not inputs.get("image_url"):
+            return ToolResult(success=False, error="image_to_video requires image_url")
+
+        try:
+            duration = int(inputs.get("duration", 5))
+        except (TypeError, ValueError):
+            return ToolResult(success=False, error="duration must be an integer from 4 to 15")
+        if not 4 <= duration <= 15:
+            return ToolResult(success=False, error="duration must be an integer from 4 to 15")
+
+        output_path, output_error = require_generated_video_output_path(inputs, self.name)
+        if output_error:
+            return output_error
+
+        api_key = _api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="MUAPI_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+
+        start = time.time()
+        payload = {
+            "prompt": inputs["prompt"],
+            "duration": duration,
+            "aspect_ratio": inputs.get("aspect_ratio", "16:9"),
+        }
+        if operation == "image_to_video":
+            payload["images_list"] = [inputs["image_url"]]
+        headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+
+        try:
+            submit = requests.post(
+                f"{_base_url()}/{model}",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            submit.raise_for_status()
+            request_id = _prediction_id(submit.json())
+            if not request_id:
+                return ToolResult(
+                    success=False,
+                    error="MuAPI video generation returned no request_id",
+                )
+
+            result_payload = self._poll_prediction(request_id, headers)
+            urls = _collect_video_urls(result_payload)
+            if not urls:
+                return ToolResult(
+                    success=False,
+                    error="MuAPI video generation completed without an output URL",
+                )
+            download_url = _safe_output_url(urls[0])
+            video_response = requests.get(
+                download_url,
+                timeout=300,
+                allow_redirects=False,
+            )
+            if 300 <= getattr(video_response, "status_code", 200) < 400:
+                return ToolResult(
+                    success=False,
+                    error="MuAPI video output redirected unexpectedly",
+                )
+            video_response.raise_for_status()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(video_response.content)
+        except Exception as exc:
+            return ToolResult(success=False, error=f"MuAPI video generation failed: {exc}")
+
+        probed = probe_output(output_path)
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "prompt": inputs["prompt"],
+                "operation": operation,
+                "duration": payload["duration"],
+                "aspect_ratio": payload["aspect_ratio"],
+                "prediction_id": request_id,
+                "output": str(output_path),
+                "output_path": str(output_path),
+                "format": "mp4",
+                **probed,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )
+
+    def _poll_prediction(
+        self,
+        request_id: str,
+        headers: dict[str, str],
+    ) -> dict[str, Any]:
+        import requests
+
+        deadline = time.time() + 600
+        delay = 2
+        while True:
+            response = requests.get(
+                f"{_base_url()}/predictions/{request_id}/result",
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            data = _status_payload(payload)
+            status = str(data.get("status", "")).lower()
+            if status in {"completed", "succeeded", "success"}:
+                return data
+            if status in {"failed", "error", "cancelled", "canceled"}:
+                message = data.get("error") or data.get("message") or status
+                raise RuntimeError(f"MuAPI video generation {message}")
+            if not status and _collect_video_urls(data):
+                return data
+            if time.time() >= deadline:
+                raise TimeoutError("MuAPI video generation timed out")
+            time.sleep(delay)
+            delay = min(delay * 2, 10)


### PR DESCRIPTION
## Summary

- add a registry-discovered `muapi_video` provider for hosted video generation
- support MuAPI Seedance 2 text-to-video and image-to-video operations with selectable standard and fast endpoints
- map the async submit, bounded poll, HTTPS-only download, output probing, and project-path contract into Video Production Buddy
- add focused mocked tests for payloads, result extraction, validation, security, and registry discovery

MuAPI video API reference: https://muapi.ai/ai-video-api

## Verification

- `ruff check tools/video/muapi_video.py tests/tools/test_muapi_video.py tests/tools/test_cloud_video_providers.py`
- `.venv/bin/python -m pytest -q tests/tools/test_muapi_video.py tests/tools/test_cloud_video_providers.py` (136 passed)
- `make test-contracts` (1,216 passed, 1 deselected)
- `git diff --check`

All provider calls in the tests are mocked; no live or billable generation request is required.
