### PR TITLE
feat(qa): add deterministic post-render technical QC

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,7 +237,7 @@ Representative capability families:
 
 | Capability | Examples |
 |------------|----------|
-| Analysis and transcription | `transcription_selector`, `transcriber`, `qwen_asr`, `scene_detect`, `frame_sampler`, `video_analyzer`, `video_understand`, `visual_qa`, `audio_probe` |
+| Analysis and transcription | `transcription_selector`, `transcriber`, `qwen_asr`, `scene_detect`, `frame_sampler`, `video_analyzer`, `video_understand`, `visual_qa`, `technical_qc`, `audio_probe` |
 | TTS and audio | `tts_selector`, `cosyvoice_tts`, `doubao_tts`, `elevenlabs_tts`, `google_tts`, `minimax_tts`, `openai_tts`, `piper_tts`, `audio_mixer`, `audio_enhance` |
 | Music | `music_selector`, `music_gen`, `minimax_music`, `suno_music`, plus search helpers such as `pixabay_music` |
 | Image generation and graphics | `image_selector`, `flux_image`, `grok_image`, `google_imagen`, `openai_image`, `recraft_image`, `wanx_image`, `local_diffusion`, stock image tools, `code_snippet`, `diagram_gen`, `math_animate` |
@@ -247,6 +247,13 @@ Representative capability families:
 | Subtitles and captions | `subtitle_gen`, `remotion_caption_burn`, and the `tools.audio.subtitle_aligner` forced-alignment utility |
 | Validation and compliance | `provider_consistency_check`, `scene_fidelity_check`, `runtime_consistency_check`, `hallucination_contract_check`, `product_identity_consistency_check`, `sample_product_visibility_check`, `compliance_check` |
 | Interaction and planning support | `genui_interaction`, `genui_session`, `genui_surface`, `ad_knowledge_retriever`, source/clip acquisition tools, screen capture selectors, character-animation tools |
+
+`technical_qc` is the deterministic post-render analysis boundary. It uses
+local FFmpeg/ffprobe passes to validate delivery metadata (dimensions, duration,
+frame rate, codecs, pixel format, audio layout, and file size) and locate black,
+frozen, or silent intervals plus loudness/clipping risks. Its JSON report is
+evidence for `render_report` and `final_review`; it does not make aesthetic
+decisions or replace watching representative sections of the render.
 
 ---
 

--- a/pipeline_defs/ad-video.yaml
+++ b/pipeline_defs/ad-video.yaml
@@ -505,6 +505,8 @@ stages:
       - hallucination_contract_check
       - video_compose
       - audio_mixer
+    optional_tools:
+      - technical_qc
     tools_available:
       - ad_video_planning_chain_check
       - provider_consistency_check
@@ -513,6 +515,7 @@ stages:
       - hallucination_contract_check
       - video_compose
       - audio_mixer
+      - technical_qc
     review_focus:
       - ad_video_planning_chain_check passes with production_bible, script, and scene_plan before render
       - provider_consistency_check passes with production_proposal, asset_manifest, script, and decision_log before render,
@@ -526,6 +529,7 @@ stages:
       - crop_regions verified present before each derivative render
       - Each derivative is a separate output file
       - render_report output resolution matches each aspect-ratio variant label; 15s/15s_short outputs are <=15s
+      - technical_qc completed for every primary and derivative output, with no failed or unresolved checks
       - Duration within ±5% of target
       - 'Audio channels: stereo'
       - final_review.status == pass after inspecting actual rendered outputs
@@ -535,6 +539,7 @@ stages:
     success_criteria:
       - render_report artifact produced
       - final_review artifact produced with status pass
+      - technical_qc reports exist for every render_report output and all required checks completed
       - final_review subtitle evidence matches production_proposal and music evidence matches the approved music_strategy
       - ad_video_planning_chain_check passed before video_compose
       - provider_consistency_check confirmed narration coverage and visual provider locks before video_compose

--- a/pipeline_defs/talking-head.yaml
+++ b/pipeline_defs/talking-head.yaml
@@ -194,7 +194,8 @@ stages:
       - remotion_caption_burn  # animated word-by-word captions via Remotion
       - showcase_card    # letterboxed showcase cards with typography
       - video_stitch     # multi-clip assembly with transitions
-      - visual_qa        # frame extraction + quality validation
+      - visual_qa        # representative frame extraction
+      - technical_qc     # deterministic whole-file technical QC
     tools_available:
       - video_compose
       - audio_mixer
@@ -210,15 +211,18 @@ stages:
       - showcase_card
       - video_stitch
       - visual_qa
+      - technical_qc
     checkpoint_required: true
     human_approval_default: false
     review_focus:
       - Output video exists and is playable
       - Subtitles are synced with speech
       - Audio is clear with balanced levels
+      - technical_qc completed and every timecoded warning was fixed or reviewed
     success_criteria:
       - Schema-valid render_report artifact
       - Output video file exists and is playable
+      - technical_qc JSON report saved and referenced by render_report metadata
 
   - name: publish
     skill: pipelines/talking-head/publish-director

--- a/skills/pipelines/ad-video/compose-director.md
+++ b/skills/pipelines/ad-video/compose-director.md
@@ -303,27 +303,66 @@ After `video_compose` returns, verify via `result.data`:
 - the output `variant` label matches the actual resolution (`16:9` is landscape, `9:16` is vertical, `1:1` is square)
 - `audio_channels` == 2 (stereo)
 
-### Check 5: Post-render loudness
+### Check 5: Whole-file technical QC
 
-Use `ffmpeg -af volumedetect` to measure mean dB on the final output and compare to `audio_contract.target_lufs`. Loudness must be within ±2 LUFS of target:
+Run `technical_qc` on the primary output. It validates the delivery profile and
+scans the complete file for black sections, long freezes, silence, integrated
+loudness, and true-peak clipping risk. This replaces an approximate
+`volumedetect` mean-volume check with EBU R128 evidence and works unchanged on
+Windows, macOS, and Linux.
 
 ```python
-import re, subprocess
-proc = subprocess.run(
-    ["ffmpeg", "-i", str(output_path), "-af", "volumedetect", "-f", "null", "/dev/null"],
-    capture_output=True, text=True
-)
-match = re.search(r"mean_volume:\s*([-\d.]+)\s*dB", proc.stderr)
-if not match:
-    raise RuntimeError("Could not measure loudness on final output")
-mean_db = float(match.group(1))
-# Approximate LUFS ≈ mean_volume for short content with loudnorm applied
-if abs(mean_db - target_lufs) > 2.5:
-    raise RuntimeError(
-        f"Loudness {mean_db:.1f} dB is more than 2.5 dB off target {target_lufs} LUFS. "
-        "Re-mix and re-encode with the correct target_lufs."
-    )
+from tools.analysis.technical_qc import TechnicalQC
+
+primary_dimensions = {
+    "16:9": (1920, 1080),
+    "9:16": (1080, 1920),
+    "1:1": (1080, 1080),
+}
+width, height = primary_dimensions[EP_STATE["aspect_ratio_primary"]]
+target_duration = edit_decisions["total_duration_seconds"]
+
+qc_result = TechnicalQC().execute({
+    "input_path": str(output_path),
+    "expected": {
+        "width": width,
+        "height": height,
+        "min_duration": target_duration * 0.95,
+        "max_duration": target_duration * 1.05,
+        "pixel_format": "yuv420p",
+        "has_audio": True,
+        "frame_rate": 30,
+        "video_codec": "h264",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+    },
+    "thresholds": {
+        "min_integrated_lufs": target_lufs - 2.5,
+        "max_integrated_lufs": target_lufs + 2.5,
+    },
+    "report_path": "projects/<project-name>/artifacts/technical_qc_primary.json",
+})
+if not qc_result.success:
+    raise RuntimeError(f"Technical QC could not run: {qc_result.error}")
+if not qc_result.data["passed"]:
+    raise RuntimeError(f"Technical QC failed: {qc_result.data['issues']}")
+
+blocking_warning_codes = {
+    "audio_too_quiet", "audio_too_loud", "audio_clipping_risk",
+}
+blocking_warnings = [
+    issue for issue in qc_result.data["issues"]
+    if issue["code"] in blocking_warning_codes
+]
+if blocking_warnings:
+    raise RuntimeError(f"Audio QC needs a new mix: {blocking_warnings}")
 ```
+
+Black, freeze, and silence findings are timecoded warnings because they can be
+intentional. Inspect each reported interval in the actual render. Re-render an
+unintentional interval; record an intentional one in
+`render_report.verification_notes` rather than silently discarding it. A
+requested check that could not complete is a failed QC result, not a pass.
 
 ### Check 6: Subtitle no-overlap (when subtitles enabled)
 
@@ -355,7 +394,11 @@ Call `audio_mixer` once per variant to produce a variant-appropriate mix (15s va
 After every derivative render, probe the actual file before adding it to
 `render_report.outputs[]`. The `variant` label, `resolution`, and
 `duration_seconds` must agree: `9:16` outputs are vertical, `1:1` outputs are
-square, and any `15s` / `15s_short` output is `<=15s`.
+square, and any `15s` / `15s_short` output is `<=15s`. Run the same
+`technical_qc` procedure for every derivative using its actual expected
+dimensions and duration, and write a distinct report such as
+`artifacts/technical_qc_9x16.json`. Do not add an output to the render report
+until its QC result completed and all warnings were either fixed or reviewed.
 
 ## Render Report Format
 
@@ -384,8 +427,17 @@ square, and any `15s` / `15s_short` output is `<=15s`.
     }
   ],
   "probe_results": {
-    "16:9": {"duration_check": "PASS", "resolution_check": "PASS", "audio_check": "PASS"},
-    "9:16": {"duration_check": "PASS", "resolution_check": "PASS", "audio_check": "PASS"}
+    "16:9": {"duration_check": "PASS", "resolution_check": "PASS", "audio_check": "PASS", "technical_qc": "PASS"},
+    "9:16": {"duration_check": "PASS", "resolution_check": "PASS", "audio_check": "PASS", "technical_qc": "WARN"}
+  },
+  "warnings": [
+    "9:16 freeze warning at 10.0-12.2s reviewed as an intentional end-card hold"
+  ],
+  "metadata": {
+    "technical_qc_reports": {
+      "16:9": "artifacts/technical_qc_primary.json",
+      "9:16": "artifacts/technical_qc_9x16.json"
+    }
   }
 }
 ```
@@ -398,7 +450,8 @@ them or advancing to publish. Write `artifacts/final_review.json` using
 
 The `final_review` must include:
 - `technical_probe` with container, duration, resolution, fps, audio, codec, and
-  file-size evidence from the rendered file
+  file-size evidence from the rendered file; derive this from the corresponding
+  `technical_qc` report and retain its path in `final_review.metadata`
 - `visual_spotcheck` with at least 4 sampled frame paths covering opening,
   middle, climax, and ending
 - `audio_spotcheck` confirming narration, silence, clipping, mix
@@ -432,7 +485,9 @@ status is `revise` or `fail`.
 - [ ] `outputs` contains `16:9` entry
 - [ ] `outputs` contains one entry per opted-in derivative (and cross-products)
 - [ ] Every `render_report.outputs[]` variant has matching resolution and short variants are `<=15s`
-- [ ] All probe results PASS
+- [ ] Probe results are PASS, or WARN only with a matching verification note
+- [ ] Every primary and derivative output has a saved `technical_qc` report
+- [ ] No Technical QC failed; every timecoded warning was fixed or explicitly reviewed
 - [ ] `render_report.renderer` matches `EP_STATE.render_runtime`
 - [ ] `final_review.status == "pass"` and every required self-review check has evidence
 - [ ] `final_review.output_path` and probe/runtime evidence match `render_report`

--- a/skills/pipelines/talking-head/compose-director.md
+++ b/skills/pipelines/talking-head/compose-director.md
@@ -418,9 +418,49 @@ video_compose.execute({
 })
 ```
 
-### Step 7: Visual QA
+### Step 7: Technical and Visual QA
 
-Use `visual_qa` to verify the output before declaring success:
+Run deterministic whole-file technical QC before visual review. This checks the
+container/profile plus black sections, long freezes, silence, integrated
+loudness, and true-peak clipping risk. Persist the JSON report with the other
+project artifacts:
+
+```
+technical_qc.execute({
+    "input_path": "<final_video>",
+    "expected": {
+        "width": 1080, "height": 1920,
+        "has_audio": true,
+        "pixel_format": "yuv420p",
+        "frame_rate": 30,
+        "video_codec": "h264",
+        "audio_codec": "aac",
+        "audio_channels": 2
+    },
+    "report_path": "projects/<project-name>/artifacts/technical_qc.json"
+})
+```
+
+- `ToolResult.success: false` means the file could not be probed or the report
+  could not be produced. Treat that as a blocker rather than assuming the
+  render passed.
+- `status: fail` means the video stream is missing, an explicitly requested
+  output profile does not match, or a requested scan could not complete. Fix
+  the cause or re-render before submitting.
+- `status: pass_with_warnings` does not automatically block delivery. Inspect
+  every reported interval because black, frozen, or silent sections may be
+  intentional editorial choices. Surface unresolved warnings in
+  `render_report` / `final_review`.
+- Technical QC is not an aesthetic review and does not replace watching the
+  render or inspecting representative frames.
+- Store the report path in `render_report.metadata.technical_qc_report`; map
+  its container evidence into `final_review.checks.technical_probe`, and map
+  unresolved interval/audio findings into the corresponding visual/audio
+  review issues. An intentional warning may be recorded as a verification note
+  after the reported interval has actually been watched.
+
+Then extract representative frames for visual inspection:
+
 ```
 visual_qa.execute({
     "operation": "review",
@@ -435,20 +475,9 @@ Then **read each extracted frame** to verify:
 - Transitions are clean (no artifacts at transition points)
 - Showcase cards have readable typography
 
-Also run probe validation:
-```
-visual_qa.execute({
-    "operation": "probe",
-    "input_path": "<final_video>",
-    "expected": {
-        "width": 1080, "height": 1920,
-        "has_audio": true,
-        "pixel_format": "yuv420p"
-    },
-})
-```
+When the edit needs point-in-time evidence (for example, comparing speech and
+showcase sections), optionally keep the sampled audio-level check:
 
-And check audio levels:
 ```
 visual_qa.execute({
     "operation": "audio_levels",
@@ -456,7 +485,8 @@ visual_qa.execute({
     "timestamps": [5.0, 50.0, 170.0],
 })
 ```
-Verify: speech sections have higher volume than showcase sections (confirms music placement).
+Verify that speech sections have higher volume than showcase sections when that
+is the approved mix intent.
 
 ### Step 8: Build Render Report
 

--- a/tests/integration/test_ffmpeg_media_smoke.py
+++ b/tests/integration/test_ffmpeg_media_smoke.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tools.analysis.technical_qc import TechnicalQC
+
 
 pytestmark = [pytest.mark.integration, pytest.mark.qa, pytest.mark.ffmpeg]
 
@@ -63,3 +65,107 @@ def test_ffmpeg_smoke_creates_probeable_video(tmp_path: Path) -> None:
     assert "codec_name=" in probe.stdout
     assert "width=320" in probe.stdout
     assert "height=180" in probe.stdout
+
+    qc_result = TechnicalQC().execute(
+        {
+            "input_path": str(output),
+            "expected": {
+                "width": 320,
+                "height": 180,
+                "pixel_format": "yuv420p",
+                "has_audio": True,
+                "frame_rate": 24,
+                "video_codec": "h264",
+                "audio_codec": "aac",
+                "audio_channels": 1,
+                "audio_sample_rate": 44100,
+                "max_file_size_mb": 10,
+            },
+        }
+    )
+
+    assert qc_result.success is True
+    assert qc_result.data["status"] == "pass"
+    assert (
+        qc_result.data["metrics"]["audio_loudness"]["integrated_lufs"]
+        is not None
+    )
+
+
+def test_technical_qc_detects_real_black_freeze_and_silence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_ffmpeg()
+    monkeypatch.chdir(tmp_path)
+    output = tmp_path / "qc-smoke.mp4"
+
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=320x180:rate=24:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=black:size=320x180:rate=24:duration=2.5",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=320x180:rate=24:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=channel_layout=stereo:sample_rate=44100:d=2.5",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-filter_complex",
+            (
+                "[0:v][1:v][2:v]concat=n=3:v=1:a=0[v];"
+                "[3:a][4:a][5:a]concat=n=3:v=0:a=1[a]"
+            ),
+            "-map",
+            "[v]",
+            "-map",
+            "[a]",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    result = TechnicalQC().execute(
+        {
+            "input_path": str(output),
+            "expected": {
+                "width": 320,
+                "height": 180,
+                "pixel_format": "yuv420p",
+                "has_audio": True,
+            },
+            "report_path": "projects/qc-smoke/artifacts/technical_qc.json",
+        }
+    )
+
+    assert result.success is True
+    assert result.data["status"] == "pass_with_warnings"
+    issue_codes = {issue["code"] for issue in result.data["issues"]}
+    assert {"black_segment", "freeze_segment", "silence_segment"} <= issue_codes
+    assert result.data["metrics"]["black_segments"]
+    assert result.data["metrics"]["freeze_segments"]
+    assert result.data["metrics"]["silence_segments"]
+    assert Path(result.data["report_path"]).is_file()

--- a/tests/tools/test_technical_qc.py
+++ b/tests/tools/test_technical_qc.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import jsonschema
+import pytest
+
+from tools.analysis.technical_qc import TechnicalQC
+from tools.tool_registry import ToolRegistry
+
+
+def _probe_payload(*, has_audio: bool = True, has_video: bool = True) -> str:
+    streams = []
+    if has_video:
+        streams.append(
+            {
+                "codec_type": "video",
+                "width": 1920,
+                "height": 1080,
+                "pix_fmt": "yuv420p",
+                "codec_name": "h264",
+                "r_frame_rate": "30/1",
+            }
+        )
+    if has_audio:
+        streams.append(
+            {
+                "codec_type": "audio",
+                "codec_name": "aac",
+                "sample_rate": "48000",
+                "channels": 2,
+            }
+        )
+    return json.dumps(
+        {
+            "format": {"duration": "10.0", "size": "2097152"},
+            "streams": streams,
+        }
+    )
+
+
+def _runner(
+    *,
+    has_audio: bool = True,
+    has_video: bool = True,
+    black_output: str = "",
+    freeze_output: str = "",
+    silence_output: str = "",
+    loudness_output: str = "I: -16.0 LUFS\nLRA: 4.0 LU\nPeak: -1.0 dBFS",
+    calls: list[list[str]] | None = None,
+):
+    def fake_run_command(self, cmd, *args, **kwargs):
+        if calls is not None:
+            calls.append(cmd)
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(
+                stdout=_probe_payload(
+                    has_audio=has_audio,
+                    has_video=has_video,
+                ),
+                stderr="",
+            )
+        command_text = " ".join(cmd)
+        outputs: list[str] = []
+        if "blackdetect=" in command_text:
+            outputs.append(black_output)
+        if "freezedetect=" in command_text:
+            outputs.append(freeze_output)
+        if "silencedetect=" in command_text:
+            outputs.append(silence_output)
+        if "ebur128=peak=true" in command_text:
+            outputs.append(loudness_output)
+        if outputs:
+            return SimpleNamespace(stdout="", stderr="\n".join(outputs))
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    return fake_run_command
+
+
+def test_technical_qc_contract_and_registry_discovery() -> None:
+    info = TechnicalQC().get_info()
+    assert info["name"] == "technical_qc"
+    assert info["capability"] == "analysis"
+    assert info["provider"] == "ffmpeg"
+    assert info["runtime"] == "local"
+    assert info["dependencies"] == ["cmd:ffmpeg", "cmd:ffprobe"]
+
+    registry = ToolRegistry()
+    registry.discover()
+    assert registry.get("technical_qc") is not None
+
+
+def test_technical_qc_clean_file_matches_output_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(TechnicalQC, "run_command", _runner(calls=calls))
+
+    result = TechnicalQC().execute({"input_path": str(input_path)})
+
+    assert result.success is True
+    assert result.data["status"] == "pass"
+    assert result.data["passed"] is True
+    assert result.data["issues"] == []
+    assert result.data["checks_run"] == [
+        "container",
+        "black_frames",
+        "freeze_frames",
+        "silence",
+        "audio_loudness",
+    ]
+    assert result.data["checks_skipped"] == []
+    assert result.data["metrics"]["audio_loudness"] == {
+        "integrated_lufs": -16.0,
+        "loudness_range_lu": 4.0,
+        "true_peak_dbfs": -1.0,
+    }
+    ffmpeg_calls = [cmd for cmd in calls if cmd[0] == "ffmpeg"]
+    assert len(ffmpeg_calls) == 2
+    assert all(command[-1] == "-" for command in ffmpeg_calls)
+    jsonschema.validate(instance=result.data, schema=TechnicalQC.output_schema)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance={**result.data, "unexpected": True},
+            schema=TechnicalQC.output_schema,
+        )
+
+
+def test_technical_qc_reports_intervals_and_loudness_warnings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        _runner(
+            black_output=(
+                "[blackdetect @ 0x1] black_start:1 black_end:2.5 "
+                "black_duration:1.5"
+            ),
+            freeze_output=(
+                "[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 3\n"
+                "[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: 2.25\n"
+                "[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: 5.25"
+            ),
+            silence_output=(
+                "[silencedetect @ 0x1] silence_start: 6\n"
+                "[silencedetect @ 0x1] silence_end: 9 | silence_duration: 3"
+            ),
+            loudness_output="I: -40.0 LUFS\nLRA: 2.0 LU\nPeak: 0.0 dBFS",
+        ),
+    )
+
+    result = TechnicalQC().execute({"input_path": str(input_path)})
+
+    assert result.success is True
+    assert result.data["status"] == "pass_with_warnings"
+    assert result.data["passed"] is True
+    assert result.data["summary"] == {
+        "total_issues": 5,
+        "error_count": 0,
+        "warning_count": 5,
+        "info_count": 0,
+    }
+    assert {issue["code"] for issue in result.data["issues"]} == {
+        "black_segment",
+        "freeze_segment",
+        "silence_segment",
+        "audio_too_quiet",
+        "audio_clipping_risk",
+    }
+    assert result.data["metrics"]["freeze_segments"] == [
+        {
+            "start_seconds": 3.0,
+            "end_seconds": 5.25,
+            "duration_seconds": 2.25,
+        }
+    ]
+    jsonschema.validate(instance=result.data, schema=TechnicalQC.output_schema)
+
+
+def test_technical_qc_profile_mismatch_fails_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+    monkeypatch.setattr(TechnicalQC, "run_command", _runner())
+
+    result = TechnicalQC().execute(
+        {
+            "input_path": str(input_path),
+            "checks": ["container"],
+            "expected": {"width": 1080, "height": 1920, "has_audio": True},
+        }
+    )
+
+    assert result.success is True
+    assert result.data["status"] == "fail"
+    assert result.data["passed"] is False
+    assert result.data["summary"]["error_count"] == 2
+    assert {issue["code"] for issue in result.data["issues"]} == {
+        "width_mismatch",
+        "height_mismatch",
+    }
+    jsonschema.validate(instance=result.data, schema=TechnicalQC.output_schema)
+
+
+def test_technical_qc_validates_extended_delivery_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+    monkeypatch.setattr(TechnicalQC, "run_command", _runner())
+
+    result = TechnicalQC().execute(
+        {
+            "input_path": str(input_path),
+            "checks": ["container"],
+            "expected": {
+                "frame_rate": 25,
+                "video_codec": "hevc",
+                "audio_codec": "mp3",
+                "audio_channels": 1,
+                "audio_sample_rate": 44100,
+                "max_file_size_mb": 1,
+            },
+        }
+    )
+
+    assert result.success is True
+    assert result.data["status"] == "fail"
+    assert {issue["code"] for issue in result.data["issues"]} == {
+        "frame_rate_mismatch",
+        "video_codec_mismatch",
+        "audio_codec_mismatch",
+        "audio_channels_mismatch",
+        "audio_sample_rate_mismatch",
+        "file_size_too_large",
+    }
+    assert result.data["media"]["frame_rate"] == 30.0
+    assert result.data["media"]["sample_rate"] == 48000
+    assert result.data["media"]["file_size_bytes"] == 2097152
+    assert result.data["media"]["file_size_mb"] == 2.097
+    jsonschema.validate(instance=result.data, schema=TechnicalQC.output_schema)
+
+
+def test_technical_qc_skips_audio_checks_without_audio_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "silent-render.mp4"
+    input_path.write_bytes(b"video")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        _runner(has_audio=False, calls=calls),
+    )
+
+    result = TechnicalQC().execute({"input_path": str(input_path)})
+
+    assert result.success is True
+    assert result.data["status"] == "pass_with_warnings"
+    assert result.data["checks_run"] == [
+        "container",
+        "black_frames",
+        "freeze_frames",
+    ]
+    assert result.data["checks_skipped"] == [
+        {"check": "silence", "reason": "input has no audio stream"},
+        {"check": "audio_loudness", "reason": "input has no audio stream"},
+    ]
+    assert [issue["code"] for issue in result.data["issues"]] == [
+        "audio_stream_missing"
+    ]
+    assert not any("silencedetect=" in " ".join(cmd) for cmd in calls)
+    assert not any("ebur128=" in " ".join(cmd) for cmd in calls)
+
+
+def test_technical_qc_accepts_intentionally_silent_video(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "intentional-silent-render.mp4"
+    input_path.write_bytes(b"video")
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        _runner(has_audio=False),
+    )
+
+    result = TechnicalQC().execute(
+        {
+            "input_path": str(input_path),
+            "expected": {"has_audio": False},
+        }
+    )
+
+    assert result.success is True
+    assert result.data["status"] == "pass"
+    assert result.data["passed"] is True
+    assert result.data["issues"] == []
+    assert [item["check"] for item in result.data["checks_skipped"]] == [
+        "silence",
+        "audio_loudness",
+    ]
+
+
+def test_technical_qc_fails_when_required_audio_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "missing-audio.mp4"
+    input_path.write_bytes(b"video")
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        _runner(has_audio=False),
+    )
+
+    result = TechnicalQC().execute(
+        {
+            "input_path": str(input_path),
+            "checks": ["container"],
+            "expected": {"has_audio": True},
+        }
+    )
+
+    assert result.success is True
+    assert result.data["status"] == "fail"
+    assert result.data["passed"] is False
+    assert [issue["code"] for issue in result.data["issues"]] == [
+        "audio_presence_mismatch"
+    ]
+
+
+def test_technical_qc_fails_when_video_stream_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "audio-only.mp4"
+    input_path.write_bytes(b"audio")
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        _runner(has_video=False),
+    )
+
+    result = TechnicalQC().execute({"input_path": str(input_path)})
+
+    assert result.success is True
+    assert result.data["status"] == "fail"
+    assert result.data["passed"] is False
+    assert [issue["code"] for issue in result.data["issues"]] == [
+        "video_stream_missing"
+    ]
+    assert [item["check"] for item in result.data["checks_skipped"]] == [
+        "black_frames",
+        "freeze_frames",
+    ]
+
+
+def test_technical_qc_writes_project_scoped_json_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+    report_path = Path("projects/demo/artifacts/technical_qc.json")
+    monkeypatch.setattr(TechnicalQC, "run_command", _runner())
+
+    result = TechnicalQC().execute(
+        {
+            "input_path": str(input_path),
+            "checks": ["container"],
+            "report_path": str(report_path),
+        }
+    )
+
+    assert result.success is True
+    assert result.data["report_path"] == report_path.as_posix()
+    assert result.artifacts == [report_path.as_posix()]
+    saved = json.loads(report_path.read_text(encoding="utf-8"))
+    assert saved == result.data
+    assert report_path.read_bytes().endswith(b"\n")
+    jsonschema.validate(instance=saved, schema=TechnicalQC.output_schema)
+
+
+@pytest.mark.parametrize(
+    "report_path",
+    ["technical_qc.json", "projects/demo/artifacts/technical_qc.txt"],
+)
+def test_technical_qc_rejects_invalid_report_path_before_probe(
+    report_path: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+    command_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        lambda self, cmd, *args, **kwargs: command_calls.append(cmd),
+    )
+
+    result = TechnicalQC().execute(
+        {"input_path": str(input_path), "report_path": report_path}
+    )
+
+    assert result.success is False
+    assert "report_path" in (result.error or "")
+    assert command_calls == []
+
+
+def test_technical_qc_schema_and_runtime_config_validation() -> None:
+    jsonschema.validate(
+        instance={"input_path": "render.mp4"},
+        schema=TechnicalQC.input_schema,
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance={
+                "input_path": "render.mp4",
+                "thresholds": {"min_black_duration_seconds": 0},
+            },
+            schema=TechnicalQC.input_schema,
+        )
+    with pytest.raises(ValueError, match="min_integrated_lufs"):
+        TechnicalQC._resolve_config(
+            {
+                "thresholds": {
+                    "min_integrated_lufs": -8,
+                    "max_integrated_lufs": -35,
+                }
+            }
+        )
+    with pytest.raises(ValueError, match="container check"):
+        TechnicalQC._resolve_config(
+            {"checks": ["black_frames"], "expected": {"width": 1920}}
+        )
+    with pytest.raises(ValueError, match="min_duration"):
+        TechnicalQC._resolve_config(
+            {"expected": {"min_duration": 10, "max_duration": 5}}
+        )
+    with pytest.raises(ValueError, match="max_integrated_lufs"):
+        TechnicalQC._resolve_config(
+            {"thresholds": {"max_integrated_lufs": 1}}
+        )
+
+
+def test_technical_qc_rejects_non_finite_probe_duration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "broken.mp4"
+    input_path.write_bytes(b"video")
+    monkeypatch.setattr(
+        TechnicalQC,
+        "run_command",
+        lambda self, cmd, *args, **kwargs: SimpleNamespace(
+            stdout=json.dumps({"format": {"duration": "NaN", "size": "1"}}),
+            stderr="",
+        ),
+    )
+
+    result = TechnicalQC().execute({"input_path": str(input_path)})
+
+    assert result.success is False
+    assert "invalid media duration" in (result.error or "")
+
+
+def test_technical_qc_interval_parser_closes_trailing_interval_at_media_end() -> None:
+    assert TechnicalQC._parse_intervals(
+        "[silencedetect @ 0x1] silence_start: 7.5",
+        "silence",
+        10.0,
+    ) == [
+        {
+            "start_seconds": 7.5,
+            "end_seconds": 10.0,
+            "duration_seconds": 2.5,
+        }
+    ]
+
+
+def test_technical_qc_parses_ntsc_frame_rate() -> None:
+    assert TechnicalQC._parse_frame_rate("30000/1001") == 29.97
+    assert TechnicalQC._parse_frame_rate("0/0") is None
+
+
+def test_technical_qc_keeps_partial_report_when_one_ffmpeg_scan_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "render.mp4"
+    input_path.write_bytes(b"video")
+
+    def fake_run_command(self, cmd, *args, **kwargs):
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(stdout=_probe_payload(), stderr="")
+        if "blackdetect=" in " ".join(cmd):
+            raise RuntimeError("video filter unavailable")
+        return SimpleNamespace(
+            stdout="",
+            stderr="I: -16.0 LUFS\nLRA: 4.0 LU\nPeak: -1.0 dBFS",
+        )
+
+    monkeypatch.setattr(TechnicalQC, "run_command", fake_run_command)
+
+    result = TechnicalQC().execute({"input_path": str(input_path)})
+
+    assert result.success is True
+    assert result.data["status"] == "fail"
+    assert result.data["passed"] is False
+    assert result.data["summary"]["error_count"] == 2
+    assert result.data["checks_run"] == [
+        "container",
+        "silence",
+        "audio_loudness",
+    ]
+    assert [item["check"] for item in result.data["checks_skipped"]] == [
+        "black_frames",
+        "freeze_frames",
+    ]
+    assert [issue["code"] for issue in result.data["issues"]] == [
+        "technical_check_failed",
+        "technical_check_failed",
+    ]

--- a/tools/analysis/technical_qc.py
+++ b/tools/analysis/technical_qc.py
@@ -1,0 +1,1224 @@
+"""Deterministic whole-file technical quality control for rendered videos.
+
+The tool detects delivery problems that are common in generated video without
+making aesthetic decisions: invalid media/profile metadata, black sections,
+long frozen sections, silence, unsafe integrated loudness, and clipping risk.
+Black/freeze/silence findings are warnings by default because they can be
+intentional editorial choices; invalid containers and explicit profile
+mismatches are errors.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import time
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolTier,
+)
+from tools.output_paths import (
+    portable_output_path,
+    require_optional_project_sidecar_path,
+)
+
+
+_NUMBER_PATTERN = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)"
+
+DEFAULT_CHECKS = [
+    "container",
+    "black_frames",
+    "freeze_frames",
+    "silence",
+    "audio_loudness",
+]
+
+DEFAULT_THRESHOLDS = {
+    "min_black_duration_seconds": 1.0,
+    "black_pixel_threshold": 0.10,
+    "black_picture_ratio_threshold": 0.98,
+    "min_freeze_duration_seconds": 2.0,
+    "freeze_noise_db": -60.0,
+    "min_silence_duration_seconds": 2.0,
+    "silence_noise_db": -50.0,
+    "min_integrated_lufs": -35.0,
+    "max_integrated_lufs": -8.0,
+    "clipping_true_peak_dbfs": -0.1,
+}
+
+_INTERVAL_SCHEMA = {
+    "type": "object",
+    "required": ["start_seconds", "end_seconds", "duration_seconds"],
+    "additionalProperties": False,
+    "properties": {
+        "start_seconds": {"type": "number", "minimum": 0},
+        "end_seconds": {"type": "number", "minimum": 0},
+        "duration_seconds": {"type": "number", "minimum": 0},
+    },
+}
+
+_NULLABLE_NUMBER = {"type": ["number", "null"]}
+
+
+class TechnicalQC(BaseTool):
+    """Scan a final render and return machine-readable technical evidence."""
+
+    name = "technical_qc"
+    version = "0.1.0"
+    tier = ToolTier.CORE
+    capability = "analysis"
+    provider = "ffmpeg"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.LOCAL
+
+    dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
+    install_instructions = "Install FFmpeg: https://ffmpeg.org/download.html"
+    agent_skills = ["ffmpeg"]
+
+    capabilities = [
+        "technical_qc",
+        "detect_black_frames",
+        "detect_freeze_frames",
+        "detect_silence",
+        "measure_integrated_loudness",
+        "validate_media_profile",
+    ]
+    supports = {
+        "local_offline": True,
+        "structured_report": True,
+        "custom_thresholds": True,
+        "partial_checks": True,
+    }
+    best_for = [
+        "checking a final render before delivery or publish",
+        "locating black, frozen, or silent intervals in generated video",
+        "validating output metadata and audio loudness without API costs",
+    ]
+    not_good_for = [
+        "aesthetic, narrative, or brand review",
+        "deciding whether an intentional pause or freeze is creatively correct",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["input_path"],
+        "properties": {
+            "input_path": {
+                "type": "string",
+                "description": "Path to the rendered video to inspect.",
+            },
+            "checks": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": True,
+                "items": {
+                    "type": "string",
+                    "enum": DEFAULT_CHECKS,
+                },
+                "description": "Checks to run. Defaults to every supported check.",
+            },
+            "expected": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "width": {"type": "integer", "minimum": 1},
+                    "height": {"type": "integer", "minimum": 1},
+                    "min_duration": {"type": "number", "minimum": 0},
+                    "max_duration": {"type": "number", "minimum": 0},
+                    "pixel_format": {"type": "string"},
+                    "has_audio": {"type": "boolean"},
+                    "frame_rate": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "description": (
+                            "Expected frames per second; NTSC rates use a "
+                            "0.05 fps tolerance."
+                        ),
+                    },
+                    "video_codec": {
+                        "type": "string",
+                        "description": (
+                            "Expected ffprobe codec_name, for example h264 "
+                            "(not libx264)."
+                        ),
+                    },
+                    "audio_codec": {
+                        "type": "string",
+                        "description": "Expected ffprobe audio codec_name, for example aac.",
+                    },
+                    "audio_channels": {"type": "integer", "minimum": 1},
+                    "audio_sample_rate": {"type": "integer", "minimum": 1},
+                    "max_file_size_mb": {"type": "number", "minimum": 0},
+                },
+                "description": (
+                    "Optional required media properties. The container check must "
+                    "be enabled when expectations are supplied."
+                ),
+            },
+            "thresholds": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "min_black_duration_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 1.0,
+                    },
+                    "black_pixel_threshold": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "default": 0.10,
+                    },
+                    "black_picture_ratio_threshold": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "default": 0.98,
+                    },
+                    "min_freeze_duration_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 2.0,
+                    },
+                    "freeze_noise_db": {
+                        "type": "number",
+                        "minimum": -100,
+                        "maximum": 0,
+                        "default": -60.0,
+                    },
+                    "min_silence_duration_seconds": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 2.0,
+                    },
+                    "silence_noise_db": {
+                        "type": "number",
+                        "minimum": -100,
+                        "maximum": 0,
+                        "default": -50.0,
+                    },
+                    "min_integrated_lufs": {
+                        "type": "number",
+                        "minimum": -100,
+                        "maximum": 0,
+                        "default": -35.0,
+                    },
+                    "max_integrated_lufs": {
+                        "type": "number",
+                        "minimum": -100,
+                        "maximum": 0,
+                        "default": -8.0,
+                    },
+                    "clipping_true_peak_dbfs": {
+                        "type": "number",
+                        "minimum": -20,
+                        "maximum": 0,
+                        "default": -0.1,
+                    },
+                },
+                "description": (
+                    "Optional conservative detection thresholds. Unspecified "
+                    "values use the tool defaults."
+                ),
+            },
+            "report_path": {
+                "type": "string",
+                "description": (
+                    "Optional .json sidecar path under projects/<project-name>/"
+                    "artifacts/..., assets/..., or renders/..."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    }
+
+    output_schema = {
+        "type": "object",
+        "required": [
+            "input",
+            "status",
+            "passed",
+            "checks_requested",
+            "checks_run",
+            "checks_skipped",
+            "thresholds",
+            "summary",
+            "issues",
+            "media",
+            "metrics",
+        ],
+        "properties": {
+            "input": {"type": "string"},
+            "status": {
+                "type": "string",
+                "enum": ["pass", "pass_with_warnings", "fail"],
+            },
+            "passed": {"type": "boolean"},
+            "checks_requested": {
+                "type": "array",
+                "items": {"type": "string", "enum": DEFAULT_CHECKS},
+            },
+            "checks_run": {
+                "type": "array",
+                "items": {"type": "string", "enum": DEFAULT_CHECKS},
+            },
+            "checks_skipped": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["check", "reason"],
+                    "additionalProperties": False,
+                    "properties": {
+                        "check": {"type": "string", "enum": DEFAULT_CHECKS},
+                        "reason": {"type": "string"},
+                    },
+                },
+            },
+            "thresholds": {
+                "type": "object",
+                "required": list(DEFAULT_THRESHOLDS),
+                "additionalProperties": False,
+                "properties": {
+                    name: {"type": "number"} for name in DEFAULT_THRESHOLDS
+                },
+            },
+            "summary": {
+                "type": "object",
+                "required": [
+                    "total_issues",
+                    "error_count",
+                    "warning_count",
+                    "info_count",
+                ],
+                "additionalProperties": False,
+                "properties": {
+                    "total_issues": {"type": "integer", "minimum": 0},
+                    "error_count": {"type": "integer", "minimum": 0},
+                    "warning_count": {"type": "integer", "minimum": 0},
+                    "info_count": {"type": "integer", "minimum": 0},
+                },
+            },
+            "issues": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["code", "severity", "message"],
+                    "additionalProperties": False,
+                    "properties": {
+                        "code": {"type": "string"},
+                        "severity": {
+                            "type": "string",
+                            "enum": ["error", "warning", "info"],
+                        },
+                        "message": {"type": "string"},
+                        "check": {"type": "string", "enum": DEFAULT_CHECKS},
+                        "start_seconds": {"type": "number", "minimum": 0},
+                        "end_seconds": {"type": "number", "minimum": 0},
+                        "duration_seconds": {"type": "number", "minimum": 0},
+                        "value": {"type": "number"},
+                        "threshold": {"type": "number"},
+                    },
+                },
+            },
+            "media": {
+                "type": "object",
+                "required": [
+                    "duration",
+                    "file_size_bytes",
+                    "file_size_mb",
+                    "has_audio",
+                ],
+                "additionalProperties": False,
+                "properties": {
+                    "duration": {"type": "number", "minimum": 0},
+                    "file_size_bytes": {"type": "integer", "minimum": 0},
+                    "file_size_mb": {"type": "number", "minimum": 0},
+                    "has_audio": {"type": "boolean"},
+                    "width": {"type": ["integer", "null"], "minimum": 1},
+                    "height": {"type": ["integer", "null"], "minimum": 1},
+                    "pixel_format": {"type": ["string", "null"]},
+                    "video_codec": {"type": ["string", "null"]},
+                    "frame_rate": {"type": ["number", "null"], "minimum": 0},
+                    "audio_codec": {"type": ["string", "null"]},
+                    "sample_rate": {"type": ["integer", "null"], "minimum": 0},
+                    "channels": {"type": ["integer", "null"], "minimum": 0},
+                },
+            },
+            "metrics": {
+                "type": "object",
+                "required": [
+                    "black_segments",
+                    "freeze_segments",
+                    "silence_segments",
+                    "audio_loudness",
+                ],
+                "additionalProperties": False,
+                "properties": {
+                    "black_segments": {
+                        "type": "array",
+                        "items": _INTERVAL_SCHEMA,
+                    },
+                    "freeze_segments": {
+                        "type": "array",
+                        "items": _INTERVAL_SCHEMA,
+                    },
+                    "silence_segments": {
+                        "type": "array",
+                        "items": _INTERVAL_SCHEMA,
+                    },
+                    "audio_loudness": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "integrated_lufs": _NULLABLE_NUMBER,
+                            "loudness_range_lu": _NULLABLE_NUMBER,
+                            "true_peak_dbfs": _NULLABLE_NUMBER,
+                        },
+                    },
+                },
+            },
+            "report_path": {"type": "string"},
+        },
+        "additionalProperties": False,
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=2,
+        ram_mb=512,
+        vram_mb=0,
+        disk_mb=20,
+        network_required=False,
+    )
+    idempotency_key_fields = [
+        "input_path",
+        "checks",
+        "expected",
+        "thresholds",
+        "report_path",
+    ]
+    side_effects = ["optionally writes a JSON sidecar to report_path"]
+    user_visible_verification = [
+        "Inspect every reported interval and confirm whether it is intentional",
+        "Watch the final render because technical QC does not judge aesthetics",
+    ]
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        input_path = Path(inputs["input_path"])
+        if not input_path.is_file():
+            return ToolResult(success=False, error=f"Input not found: {input_path}")
+
+        start = time.time()
+        try:
+            checks, thresholds = self._resolve_config(inputs)
+            report_path, report_error = require_optional_project_sidecar_path(
+                inputs,
+                "report_path",
+                self.name,
+                artifact_label="technical-QC report",
+            )
+            if report_error:
+                return report_error
+            if report_path is not None and report_path.suffix.lower() != ".json":
+                return ToolResult(
+                    success=False,
+                    error="technical_qc: report_path must use the .json extension",
+                )
+
+            media = self._probe(input_path)
+            data = self._build_report(
+                input_path,
+                checks,
+                thresholds,
+                inputs.get("expected", {}),
+                media,
+            )
+
+            artifacts: list[str] = []
+            if report_path is not None:
+                portable_report_path = portable_output_path(report_path)
+                data["report_path"] = portable_report_path
+                report_path.parent.mkdir(parents=True, exist_ok=True)
+                report_path.write_text(
+                    json.dumps(data, indent=2, allow_nan=False) + "\n",
+                    encoding="utf-8",
+                )
+                artifacts.append(portable_report_path)
+
+            return ToolResult(
+                success=True,
+                data=data,
+                artifacts=artifacts,
+                duration_seconds=round(time.time() - start, 2),
+            )
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Technical QC failed: {exc}")
+
+    def _build_report(
+        self,
+        input_path: Path,
+        checks: list[str],
+        thresholds: dict[str, float],
+        expected: dict[str, Any],
+        media: dict[str, Any],
+    ) -> dict[str, Any]:
+        duration = float(media.get("duration", 0.0))
+        has_video = bool(media.get("video_codec"))
+        has_audio = bool(media.get("has_audio"))
+        issues: list[dict[str, Any]] = []
+        checks_run: list[str] = []
+        checks_skipped: list[dict[str, str]] = []
+        metrics: dict[str, Any] = {
+            "black_segments": [],
+            "freeze_segments": [],
+            "silence_segments": [],
+            "audio_loudness": {},
+        }
+
+        if "container" in checks:
+            checks_run.append("container")
+            issues.extend(self._profile_issues(media, expected))
+        if not has_video:
+            issues.append(
+                self._issue(
+                    "video_stream_missing",
+                    "error",
+                    "No video stream was found in the input file.",
+                    check="container",
+                )
+            )
+
+        video_checks = [
+            check
+            for check in ("black_frames", "freeze_frames")
+            if check in checks
+        ]
+        if video_checks and has_video:
+            self._run_video_checks(
+                input_path,
+                duration,
+                video_checks,
+                thresholds,
+                metrics,
+                issues,
+                checks_run,
+                checks_skipped,
+            )
+        elif video_checks:
+            for check in video_checks:
+                self._skip(checks_skipped, check, "input has no video stream")
+
+        audio_checks = [
+            check
+            for check in ("silence", "audio_loudness")
+            if check in checks
+        ]
+        if audio_checks and has_audio:
+            self._run_audio_checks(
+                input_path,
+                duration,
+                audio_checks,
+                thresholds,
+                metrics,
+                issues,
+                checks_run,
+                checks_skipped,
+            )
+        elif audio_checks:
+            if "has_audio" not in expected:
+                issues.append(
+                    self._issue(
+                        "audio_stream_missing",
+                        "warning",
+                        "No audio stream was found; audio checks were skipped.",
+                        check="container",
+                    )
+                )
+            for check in audio_checks:
+                self._skip(checks_skipped, check, "input has no audio stream")
+
+        counts = {
+            severity: sum(1 for issue in issues if issue["severity"] == severity)
+            for severity in ("error", "warning", "info")
+        }
+        status = (
+            "fail"
+            if counts["error"]
+            else "pass_with_warnings"
+            if counts["warning"]
+            else "pass"
+        )
+        return {
+            "input": portable_output_path(input_path),
+            "status": status,
+            "passed": status != "fail",
+            "checks_requested": checks,
+            "checks_run": checks_run,
+            "checks_skipped": checks_skipped,
+            "thresholds": thresholds,
+            "summary": {
+                "total_issues": len(issues),
+                "error_count": counts["error"],
+                "warning_count": counts["warning"],
+                "info_count": counts["info"],
+            },
+            "issues": issues,
+            "media": media,
+            "metrics": metrics,
+        }
+
+    def _run_video_checks(
+        self,
+        input_path: Path,
+        duration: float,
+        checks: list[str],
+        thresholds: dict[str, float],
+        metrics: dict[str, Any],
+        issues: list[dict[str, Any]],
+        checks_run: list[str],
+        checks_skipped: list[dict[str, str]],
+    ) -> None:
+        filters: list[str] = []
+        if "black_frames" in checks:
+            filters.append(
+                "blackdetect="
+                f"d={thresholds['min_black_duration_seconds']}:"
+                f"pix_th={thresholds['black_pixel_threshold']}:"
+                f"pic_th={thresholds['black_picture_ratio_threshold']}"
+            )
+        if "freeze_frames" in checks:
+            filters.append(
+                "freezedetect="
+                f"n={thresholds['freeze_noise_db']}dB:"
+                f"d={thresholds['min_freeze_duration_seconds']}"
+            )
+        try:
+            result = self.run_command(
+                [
+                    "ffmpeg",
+                    "-hide_banner",
+                    "-nostats",
+                    "-nostdin",
+                    "-i",
+                    str(input_path),
+                    "-map",
+                    "0:v:0",
+                    "-vf",
+                    ",".join(filters),
+                    "-an",
+                    "-f",
+                    "null",
+                    "-",
+                ],
+                timeout=600,
+            )
+        except Exception as exc:
+            for check in checks:
+                self._record_failure(check, exc, issues, checks_skipped)
+            return
+
+        output = result.stderr or ""
+        if "black_frames" in checks:
+            checks_run.append("black_frames")
+            segments = self._parse_intervals(output, "black", duration)
+            metrics["black_segments"] = segments
+            issues.extend(
+                self._interval_issues(
+                    "black_segment",
+                    "black_frames",
+                    "Black section detected",
+                    segments,
+                )
+            )
+        if "freeze_frames" in checks:
+            checks_run.append("freeze_frames")
+            segments = self._parse_intervals(output, "freeze", duration)
+            metrics["freeze_segments"] = segments
+            issues.extend(
+                self._interval_issues(
+                    "freeze_segment",
+                    "freeze_frames",
+                    "Frozen section detected",
+                    segments,
+                )
+            )
+
+    def _run_audio_checks(
+        self,
+        input_path: Path,
+        duration: float,
+        checks: list[str],
+        thresholds: dict[str, float],
+        metrics: dict[str, Any],
+        issues: list[dict[str, Any]],
+        checks_run: list[str],
+        checks_skipped: list[dict[str, str]],
+    ) -> None:
+        filters: list[str] = []
+        if "silence" in checks:
+            filters.append(
+                "silencedetect="
+                f"n={thresholds['silence_noise_db']}dB:"
+                f"d={thresholds['min_silence_duration_seconds']}"
+            )
+        if "audio_loudness" in checks:
+            filters.append("ebur128=peak=true")
+        try:
+            result = self.run_command(
+                [
+                    "ffmpeg",
+                    "-hide_banner",
+                    "-nostats",
+                    "-nostdin",
+                    "-i",
+                    str(input_path),
+                    "-map",
+                    "0:a:0",
+                    "-af",
+                    ",".join(filters),
+                    "-vn",
+                    "-f",
+                    "null",
+                    "-",
+                ],
+                timeout=600,
+            )
+        except Exception as exc:
+            for check in checks:
+                self._record_failure(check, exc, issues, checks_skipped)
+            return
+
+        output = result.stderr or ""
+        if "silence" in checks:
+            checks_run.append("silence")
+            segments = self._parse_intervals(output, "silence", duration)
+            metrics["silence_segments"] = segments
+            issues.extend(
+                self._interval_issues(
+                    "silence_segment",
+                    "silence",
+                    "Silent section detected",
+                    segments,
+                )
+            )
+        if "audio_loudness" in checks:
+            loudness = self._parse_loudness(output)
+            metrics["audio_loudness"] = loudness
+            if loudness["integrated_lufs"] is None:
+                reason = "FFmpeg completed but reported no integrated loudness"
+                self._skip(checks_skipped, "audio_loudness", reason)
+                issues.append(
+                    self._issue(
+                        "audio_loudness_unavailable",
+                        "warning",
+                        reason + ".",
+                        check="audio_loudness",
+                    )
+                )
+            else:
+                checks_run.append("audio_loudness")
+                self._append_loudness_issues(issues, loudness, thresholds)
+
+    def _probe(self, input_path: Path) -> dict[str, Any]:
+        result = self.run_command(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration,size:stream=width,height,codec_name,pix_fmt,"
+                "r_frame_rate,sample_rate,channels,codec_type",
+                "-of",
+                "json",
+                str(input_path),
+            ]
+        )
+        probe_data = json.loads(result.stdout)
+        video_stream = next(
+            (
+                stream
+                for stream in probe_data.get("streams", [])
+                if stream.get("codec_type") == "video"
+            ),
+            None,
+        )
+        audio_stream = next(
+            (
+                stream
+                for stream in probe_data.get("streams", [])
+                if stream.get("codec_type") == "audio"
+            ),
+            None,
+        )
+        format_info = probe_data.get("format", {})
+        duration = float(format_info.get("duration", 0))
+        file_size_bytes = int(format_info.get("size", 0))
+        if not math.isfinite(duration) or duration < 0:
+            raise ValueError("ffprobe returned an invalid media duration")
+        if file_size_bytes < 0:
+            raise ValueError("ffprobe returned an invalid media size")
+
+        info: dict[str, Any] = {
+            "duration": duration,
+            "file_size_bytes": file_size_bytes,
+            "file_size_mb": round(file_size_bytes / 1_000_000, 3),
+            "has_audio": audio_stream is not None,
+        }
+        if video_stream:
+            info.update(
+                {
+                    "width": video_stream.get("width"),
+                    "height": video_stream.get("height"),
+                    "pixel_format": video_stream.get("pix_fmt"),
+                    "video_codec": video_stream.get("codec_name"),
+                    "frame_rate": self._parse_frame_rate(
+                        video_stream.get("r_frame_rate")
+                    ),
+                }
+            )
+        if audio_stream:
+            info.update(
+                {
+                    "audio_codec": audio_stream.get("codec_name"),
+                    "sample_rate": self._parse_optional_int(
+                        audio_stream.get("sample_rate")
+                    ),
+                    "channels": audio_stream.get("channels"),
+                }
+            )
+        return info
+
+    @staticmethod
+    def _profile_issues(
+        media: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        issues: list[dict[str, Any]] = []
+        comparisons = [
+            ("width", "width_mismatch", "Width"),
+            ("height", "height_mismatch", "Height"),
+            ("pixel_format", "pixel_format_mismatch", "Pixel format"),
+            ("has_audio", "audio_presence_mismatch", "Audio presence"),
+            ("video_codec", "video_codec_mismatch", "Video codec"),
+            ("audio_codec", "audio_codec_mismatch", "Audio codec"),
+        ]
+        for field, code, label in comparisons:
+            if field in expected and media.get(field) != expected[field]:
+                issues.append(
+                    TechnicalQC._issue(
+                        code,
+                        "error",
+                        f"{label}: expected {expected[field]!r}, got {media.get(field)!r}.",
+                        check="container",
+                    )
+                )
+        if (
+            "min_duration" in expected
+            and media["duration"] < expected["min_duration"]
+        ):
+            issues.append(
+                TechnicalQC._issue(
+                    "duration_too_short",
+                    "error",
+                    (
+                        f"Duration {media['duration']:.3f}s is below the expected "
+                        f"minimum {expected['min_duration']}s."
+                    ),
+                    check="container",
+                )
+            )
+        if (
+            "max_duration" in expected
+            and media["duration"] > expected["max_duration"]
+        ):
+            issues.append(
+                TechnicalQC._issue(
+                    "duration_too_long",
+                    "error",
+                    (
+                        f"Duration {media['duration']:.3f}s exceeds the expected "
+                        f"maximum {expected['max_duration']}s."
+                    ),
+                    check="container",
+                )
+            )
+        if "frame_rate" in expected:
+            actual_frame_rate = media.get("frame_rate")
+            if actual_frame_rate is None or not math.isclose(
+                actual_frame_rate,
+                expected["frame_rate"],
+                abs_tol=0.05,
+            ):
+                issues.append(
+                    TechnicalQC._issue(
+                        "frame_rate_mismatch",
+                        "error",
+                        (
+                            f"Frame rate: expected {expected['frame_rate']!r}, "
+                            f"got {actual_frame_rate!r}."
+                        ),
+                        check="container",
+                    )
+                )
+        if (
+            "audio_channels" in expected
+            and media.get("channels") != expected["audio_channels"]
+        ):
+            issues.append(
+                TechnicalQC._issue(
+                    "audio_channels_mismatch",
+                    "error",
+                    (
+                        f"Audio channels: expected {expected['audio_channels']!r}, "
+                        f"got {media.get('channels')!r}."
+                    ),
+                    check="container",
+                )
+            )
+        if (
+            "audio_sample_rate" in expected
+            and media.get("sample_rate") != expected["audio_sample_rate"]
+        ):
+            issues.append(
+                TechnicalQC._issue(
+                    "audio_sample_rate_mismatch",
+                    "error",
+                    (
+                        "Audio sample rate: expected "
+                        f"{expected['audio_sample_rate']!r}, "
+                        f"got {media.get('sample_rate')!r}."
+                    ),
+                    check="container",
+                )
+            )
+        if (
+            "max_file_size_mb" in expected
+            and media["file_size_bytes"]
+            > expected["max_file_size_mb"] * 1_000_000
+        ):
+            issues.append(
+                TechnicalQC._issue(
+                    "file_size_too_large",
+                    "error",
+                    (
+                        f"File size {media['file_size_mb']:.3f} MB exceeds the "
+                        f"expected maximum {expected['max_file_size_mb']} MB."
+                    ),
+                    check="container",
+                )
+            )
+        return issues
+
+    @staticmethod
+    def _resolve_config(
+        inputs: dict[str, Any],
+    ) -> tuple[list[str], dict[str, float]]:
+        checks = inputs.get("checks", DEFAULT_CHECKS)
+        if not isinstance(checks, list) or not checks:
+            raise ValueError("checks must be a non-empty list")
+        if len(checks) != len(set(checks)):
+            raise ValueError("checks must not contain duplicates")
+        unknown = sorted(set(checks) - set(DEFAULT_CHECKS))
+        if unknown:
+            raise ValueError("unknown checks: " + ", ".join(unknown))
+        if inputs.get("expected") and "container" not in checks:
+            raise ValueError("container check is required when expected values are set")
+
+        expected = inputs.get("expected", {})
+        if not isinstance(expected, dict):
+            raise ValueError("expected must be an object")
+        for name in (
+            "min_duration",
+            "max_duration",
+            "frame_rate",
+            "max_file_size_mb",
+        ):
+            if name not in expected:
+                continue
+            value = expected[name]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                or value < 0
+            ):
+                raise ValueError(
+                    f"expected.{name} must be a finite non-negative number"
+                )
+        if expected.get("frame_rate") == 0:
+            raise ValueError("expected.frame_rate must be greater than zero")
+        if (
+            "min_duration" in expected
+            and "max_duration" in expected
+            and expected["min_duration"] > expected["max_duration"]
+        ):
+            raise ValueError(
+                "expected.min_duration must not exceed expected.max_duration"
+            )
+
+        overrides = inputs.get("thresholds", {})
+        if not isinstance(overrides, dict):
+            raise ValueError("thresholds must be an object")
+        unknown_thresholds = sorted(set(overrides) - set(DEFAULT_THRESHOLDS))
+        if unknown_thresholds:
+            raise ValueError(
+                "unknown thresholds: " + ", ".join(unknown_thresholds)
+            )
+        thresholds = {**DEFAULT_THRESHOLDS, **overrides}
+        for name, value in thresholds.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"{name} must be a finite number")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be a finite number")
+            thresholds[name] = float(value)
+
+        for name in (
+            "min_black_duration_seconds",
+            "min_freeze_duration_seconds",
+            "min_silence_duration_seconds",
+        ):
+            if thresholds[name] <= 0:
+                raise ValueError(f"{name} must be greater than zero")
+        for name in (
+            "black_pixel_threshold",
+            "black_picture_ratio_threshold",
+        ):
+            if not 0 <= thresholds[name] <= 1:
+                raise ValueError(f"{name} must be between 0 and 1")
+        for name in ("freeze_noise_db", "silence_noise_db"):
+            if not -100 <= thresholds[name] <= 0:
+                raise ValueError(f"{name} must be between -100 and 0")
+        for name in ("min_integrated_lufs", "max_integrated_lufs"):
+            if not -100 <= thresholds[name] <= 0:
+                raise ValueError(f"{name} must be between -100 and 0")
+        if thresholds["min_integrated_lufs"] >= thresholds["max_integrated_lufs"]:
+            raise ValueError(
+                "min_integrated_lufs must be less than max_integrated_lufs"
+            )
+        if not -20 <= thresholds["clipping_true_peak_dbfs"] <= 0:
+            raise ValueError(
+                "clipping_true_peak_dbfs must be between -20 and 0"
+            )
+        return list(checks), thresholds
+
+    @staticmethod
+    def _parse_frame_rate(value: Any) -> float | None:
+        if value in (None, "", "0/0"):
+            return None
+        try:
+            rate = float(Fraction(str(value)))
+        except (ValueError, ZeroDivisionError):
+            return None
+        if not math.isfinite(rate) or rate < 0:
+            return None
+        return round(rate, 3)
+
+    @staticmethod
+    def _parse_optional_int(value: Any) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed >= 0 else None
+
+    @staticmethod
+    def _parse_intervals(
+        output: str,
+        prefix: str,
+        media_duration: float,
+    ) -> list[dict[str, float]]:
+        starts = [
+            float(value)
+            for value in re.findall(
+                rf"(?:lavfi\.)?{prefix}_start:\s*({_NUMBER_PATTERN})",
+                output,
+            )
+        ]
+        ends = [
+            float(value)
+            for value in re.findall(
+                rf"(?:lavfi\.)?{prefix}_end:\s*({_NUMBER_PATTERN})",
+                output,
+            )
+        ]
+        durations = [
+            float(value)
+            for value in re.findall(
+                rf"(?:lavfi\.)?{prefix}_duration:\s*({_NUMBER_PATTERN})",
+                output,
+            )
+        ]
+        segments: list[dict[str, float]] = []
+        for index, start in enumerate(starts):
+            if index < len(ends):
+                end = ends[index]
+            elif index < len(durations):
+                end = start + durations[index]
+            else:
+                end = max(media_duration, start)
+            segment_duration = (
+                durations[index]
+                if index < len(durations)
+                else max(end - start, 0.0)
+            )
+            segments.append(
+                {
+                    "start_seconds": round(max(start, 0.0), 3),
+                    "end_seconds": round(max(end, start), 3),
+                    "duration_seconds": round(max(segment_duration, 0.0), 3),
+                }
+            )
+        return segments
+
+    @staticmethod
+    def _parse_loudness(output: str) -> dict[str, float | None]:
+        integrated_values = re.findall(
+            rf"\bI:\s*({_NUMBER_PATTERN})\s+LUFS",
+            output,
+        )
+        range_values = re.findall(
+            rf"\bLRA:\s*({_NUMBER_PATTERN})\s+LU",
+            output,
+        )
+        peak_values = re.findall(
+            rf"\bPeak:\s*({_NUMBER_PATTERN})\s+dBFS",
+            output,
+        )
+        return {
+            "integrated_lufs": (
+                round(float(integrated_values[-1]), 2)
+                if integrated_values
+                else None
+            ),
+            "loudness_range_lu": (
+                round(float(range_values[-1]), 2) if range_values else None
+            ),
+            "true_peak_dbfs": (
+                round(float(peak_values[-1]), 2) if peak_values else None
+            ),
+        }
+
+    @staticmethod
+    def _interval_issues(
+        code: str,
+        check: str,
+        label: str,
+        segments: list[dict[str, float]],
+    ) -> list[dict[str, Any]]:
+        return [
+            TechnicalQC._issue(
+                code,
+                "warning",
+                (
+                    f"{label} from {segment['start_seconds']:.3f}s to "
+                    f"{segment['end_seconds']:.3f}s "
+                    f"({segment['duration_seconds']:.3f}s)."
+                ),
+                check=check,
+                **segment,
+            )
+            for segment in segments
+        ]
+
+    @staticmethod
+    def _append_loudness_issues(
+        issues: list[dict[str, Any]],
+        loudness: dict[str, float | None],
+        thresholds: dict[str, float],
+    ) -> None:
+        integrated = loudness["integrated_lufs"]
+        if integrated is not None and integrated < thresholds["min_integrated_lufs"]:
+            issues.append(
+                TechnicalQC._issue(
+                    "audio_too_quiet",
+                    "warning",
+                    f"Integrated loudness is very low ({integrated:.2f} LUFS).",
+                    check="audio_loudness",
+                    value=integrated,
+                    threshold=thresholds["min_integrated_lufs"],
+                )
+            )
+        if integrated is not None and integrated > thresholds["max_integrated_lufs"]:
+            issues.append(
+                TechnicalQC._issue(
+                    "audio_too_loud",
+                    "warning",
+                    f"Integrated loudness is very high ({integrated:.2f} LUFS).",
+                    check="audio_loudness",
+                    value=integrated,
+                    threshold=thresholds["max_integrated_lufs"],
+                )
+            )
+        true_peak = loudness["true_peak_dbfs"]
+        if (
+            true_peak is not None
+            and true_peak >= thresholds["clipping_true_peak_dbfs"]
+        ):
+            issues.append(
+                TechnicalQC._issue(
+                    "audio_clipping_risk",
+                    "warning",
+                    f"True peak is close to full scale ({true_peak:.2f} dBFS).",
+                    check="audio_loudness",
+                    value=true_peak,
+                    threshold=thresholds["clipping_true_peak_dbfs"],
+                )
+            )
+
+    @staticmethod
+    def _issue(
+        code: str,
+        severity: str,
+        message: str,
+        **evidence: Any,
+    ) -> dict[str, Any]:
+        return {
+            "code": code,
+            "severity": severity,
+            "message": message,
+            **evidence,
+        }
+
+    @staticmethod
+    def _skip(
+        skipped: list[dict[str, str]],
+        check: str,
+        reason: str,
+    ) -> None:
+        skipped.append({"check": check, "reason": reason})
+
+    @staticmethod
+    def _record_failure(
+        check: str,
+        error: Exception,
+        issues: list[dict[str, Any]],
+        skipped: list[dict[str, str]],
+    ) -> None:
+        reason = f"FFmpeg check failed: {error}"
+        TechnicalQC._skip(skipped, check, reason)
+        issues.append(
+            TechnicalQC._issue(
+                "technical_check_failed",
+                "error",
+                reason,
+                check=check,
+            )
+        )


### PR DESCRIPTION
## Summary

Add deterministic post-render technical quality control based on FFmpeg and ffprobe.

The new `technical_qc` tool checks rendered videos for common technical issues such as black frames, frozen frames, long silence, abnormal loudness, clipping, and delivery-profile mismatches. It produces a structured JSON report that can be used during final review before a video is approved or delivered.

The tool runs locally, requires no API key or network access, and does not modify the rendered video.

## Related issue

N/A

## Changes

- Add the `technical_qc` analysis tool using FFmpeg and ffprobe.
- Detect black-frame, freeze-frame, and silence intervals with timestamps.
- Measure integrated loudness and true peak for loudness and clipping warnings.
- Validate optional delivery requirements, including:
  - dimensions and duration
  - frame rate and pixel format
  - video and audio codecs
  - audio channels and sample rate
  - audio-stream presence
  - maximum file size
- Return structured pass, warning, and failure results.
- Support portable JSON report output inside the project directory.
- Handle missing audio and missing video streams explicitly.
- Fail closed when a requested FFmpeg analysis cannot be completed.
- Integrate post-render technical QC into the ad-video and talking-head pipelines.
- Add unit tests, real FFmpeg integration tests, and architecture documentation.

## Testing

- `pytest tests/tools/test_technical_qc.py`
  - 17 passed
- `pytest tests/integration/test_ffmpeg_media_smoke.py`
  - 2 passed
- Relevant pipeline, schema, registry, and repository contract tests
  - 423 passed
- Full tool test suite
  - 1221 passed, 13 deselected
- Broader contract regression suite
  - 1194 passed, 1 deselected
- `git diff --check`
  - passed
- Tested locally on Windows with real FFmpeg-generated media fixtures.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
