### PR TITLE
feat(qc): add context-aware review for technical findings

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,7 +253,15 @@ local FFmpeg/ffprobe passes to validate delivery metadata (dimensions, duration,
 frame rate, codecs, pixel format, audio layout, and file size) and locate black,
 frozen, or silent intervals plus loudness/clipping risks. Its JSON report is
 evidence for `render_report` and `final_review`; it does not make aesthetic
-decisions or replace watching representative sections of the render.
+decisions or replace watching representative sections of the render. The
+`technical-qc-review` meta skill is the contextual layer: the agent maps each
+warning to scene/edit/audio intent, inspects time-local evidence, and records a
+`defect`, `intentional`, or `uncertain` disposition in `final_review`. When the
+registry has a genuine gap, project-scoped Agent-authored diagnostics may add
+evidence under the capability-extension protocol, but they cannot override
+canonical decode/profile failures or establish a pass by themselves. These
+diagnostics remain disposable `project_only` evidence by default; converting
+one into a shared tool is never an automatic pipeline responsibility.
 
 ---
 

--- a/pipeline_defs/ad-video.yaml
+++ b/pipeline_defs/ad-video.yaml
@@ -34,6 +34,7 @@ required_skills:
   - skills/pipelines/ad-video/publish-director.md
   - skills/pipelines/ad-video/research-director.md
   - skills/pipelines/ad-video/technical-proposal-director.md
+  - skills/meta/technical-qc-review.md
 stages:
   - name: research
     skill: pipelines/ad-video/research-director
@@ -529,10 +530,11 @@ stages:
       - crop_regions verified present before each derivative render
       - Each derivative is a separate output file
       - render_report output resolution matches each aspect-ratio variant label; 15s/15s_short outputs are <=15s
-      - technical_qc completed for every primary and derivative output, with no failed or unresolved checks
+      - technical_qc completed for every primary and derivative output, with every context-sensitive warning assigned a disposition through the technical-qc-review skill
       - Duration within ±5% of target
       - 'Audio channels: stereo'
       - final_review.status == pass after inspecting actual rendered outputs
+      - final_review.checks.technical_qc_review records evidence-backed dispositions with unresolved_count == 0
       - final_review.output_path and probe/runtime evidence match render_report.outputs
       - final_review subtitle evidence matches production_proposal and music presence evidence matches the approved music_strategy
       - final_review.reviewed_outputs covers every render_report.outputs file when derivative outputs exist
@@ -540,6 +542,7 @@ stages:
       - render_report artifact produced
       - final_review artifact produced with status pass
       - technical_qc reports exist for every render_report output and all required checks completed
+      - final_review contains one contextual technical_qc_review output entry per rendered output with zero unresolved findings
       - final_review subtitle evidence matches production_proposal and music evidence matches the approved music_strategy
       - ad_video_planning_chain_check passed before video_compose
       - provider_consistency_check confirmed narration coverage and visual provider locks before video_compose

--- a/pipeline_defs/talking-head.yaml
+++ b/pipeline_defs/talking-head.yaml
@@ -24,6 +24,7 @@ required_skills:
   - pipelines/talking-head/compose-director
   - pipelines/talking-head/publish-director
   - meta/reviewer
+  - meta/technical-qc-review
   - meta/checkpoint-protocol
 
 orchestration:
@@ -218,11 +219,12 @@ stages:
       - Output video exists and is playable
       - Subtitles are synced with speech
       - Audio is clear with balanced levels
-      - technical_qc completed and every timecoded warning was fixed or reviewed
+      - technical_qc completed and every context-sensitive warning was assigned a disposition through the technical-qc-review skill
     success_criteria:
       - Schema-valid render_report artifact
       - Output video file exists and is playable
       - technical_qc JSON report saved and referenced by render_report metadata
+      - final_review.checks.technical_qc_review has evidence-backed dispositions and unresolved_count == 0 when final_review.status == pass
 
   - name: publish
     skill: pipelines/talking-head/publish-director

--- a/schemas/artifacts/__init__.py
+++ b/schemas/artifacts/__init__.py
@@ -1970,6 +1970,228 @@ def _validate_ad_video_render_report(
         )
 
 
+def _validate_contextual_technical_qc_review(
+    final_review: dict[str, Any],
+    *,
+    pipeline_type: str | None,
+    related_artifacts: dict[str, Any] | None = None,
+) -> None:
+    """Require contextual QC evidence for pipelines that opt into the protocol."""
+    if pipeline_type not in {"ad-video", "talking-head"}:
+        return
+
+    checks = final_review.get("checks")
+    technical_review = (
+        checks.get("technical_qc_review") if isinstance(checks, dict) else None
+    )
+    if not isinstance(technical_review, dict):
+        if final_review.get("status") != "pass":
+            return
+        raise jsonschema.ValidationError(
+            f"{pipeline_type} final_review.status='pass' requires "
+            "checks.technical_qc_review"
+        )
+    if (
+        final_review.get("status") == "pass"
+        and technical_review.get("unresolved_count") != 0
+    ):
+        raise jsonschema.ValidationError(
+            f"{pipeline_type} final_review.checks.technical_qc_review."
+            "unresolved_count must be 0 when status is pass"
+        )
+
+    output_reviews = technical_review.get("outputs")
+    if not isinstance(output_reviews, list) or not output_reviews:
+        raise jsonschema.ValidationError(
+            f"{pipeline_type} final_review.checks.technical_qc_review.outputs "
+            "must contain at least one output review"
+        )
+
+    reviewed_paths: set[str] = set()
+    report_paths: set[str] = set()
+    review_by_path: dict[str, dict[str, Any]] = {}
+    expected_unresolved_total = 0
+    for idx, output_review in enumerate(output_reviews):
+        if not isinstance(output_review, dict):
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}] must be an object"
+            )
+        output_path = output_review.get("output_path")
+        report_path = output_review.get("report_path")
+        if not isinstance(output_path, str) or not output_path.strip():
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}].output_path "
+                "must be non-empty"
+            )
+        if not isinstance(report_path, str) or not report_path.strip():
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}].report_path "
+                "must be non-empty"
+            )
+        output_path = output_path.strip()
+        report_path = report_path.strip()
+        if output_path in reviewed_paths:
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs contains duplicate "
+                f"output_path {output_path!r}"
+            )
+        if report_path in report_paths:
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs contains duplicate "
+                f"report_path {report_path!r}"
+            )
+        reviewed_paths.add(output_path)
+        report_paths.add(report_path)
+        review_by_path[output_path] = output_review
+
+        findings = output_review.get("findings")
+        scan_status = output_review.get("scan_status")
+        warning_count = output_review.get("warning_count")
+        canonical_finding_count = sum(
+            1
+            for finding in findings or []
+            if isinstance(finding, dict) and finding.get("source") == "technical_qc"
+        )
+        if warning_count != canonical_finding_count:
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}].warning_count "
+                "must equal the number of findings sourced from technical_qc"
+            )
+        if scan_status == "pass" and warning_count != 0:
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}] with "
+                "scan_status='pass' must have warning_count 0"
+            )
+        if scan_status == "pass_with_warnings" and warning_count == 0:
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}] with "
+                "scan_status='pass_with_warnings' must have at least one warning"
+            )
+        for finding_idx, finding in enumerate(findings or []):
+            if not isinstance(finding, dict):
+                continue
+            start_seconds = finding.get("start_seconds")
+            end_seconds = finding.get("end_seconds")
+            has_start = isinstance(start_seconds, (int, float))
+            has_end = isinstance(end_seconds, (int, float))
+            if has_start != has_end:
+                raise jsonschema.ValidationError(
+                    f"{pipeline_type} technical_qc_review.outputs[{idx}]."
+                    f"findings[{finding_idx}] must provide both start_seconds "
+                    "and end_seconds, or neither"
+                )
+            if has_start and has_end and float(end_seconds) < float(start_seconds):
+                raise jsonschema.ValidationError(
+                    f"{pipeline_type} technical_qc_review.outputs[{idx}]."
+                    f"findings[{finding_idx}].end_seconds must be greater than "
+                    "or equal to start_seconds"
+                )
+        expected_output_unresolved = sum(
+            1
+            for finding in findings or []
+            if isinstance(finding, dict)
+            and finding.get("disposition") in {"defect", "uncertain"}
+        )
+        if output_review.get("unresolved_count") != expected_output_unresolved:
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs[{idx}]."
+                "unresolved_count must equal the number of defect or uncertain "
+                "findings"
+            )
+        expected_unresolved_total += expected_output_unresolved
+
+    if technical_review.get("unresolved_count") != expected_unresolved_total:
+        raise jsonschema.ValidationError(
+            f"{pipeline_type} technical_qc_review.unresolved_count must equal "
+            "the sum of per-output unresolved findings"
+        )
+
+    explicit_reviewed_outputs = final_review.get("reviewed_outputs")
+    explicit_reviewed_paths = {
+        reviewed.get("path").strip()
+        for reviewed in explicit_reviewed_outputs or []
+        if isinstance(reviewed, dict)
+        and isinstance(reviewed.get("path"), str)
+        and reviewed.get("path").strip()
+    }
+    if explicit_reviewed_paths and explicit_reviewed_paths != reviewed_paths:
+        missing = sorted(explicit_reviewed_paths - reviewed_paths)
+        extra = sorted(reviewed_paths - explicit_reviewed_paths)
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(repr(path) for path in missing))
+        if extra:
+            details.append("unknown " + ", ".join(repr(path) for path in extra))
+        raise jsonschema.ValidationError(
+            f"{pipeline_type} technical_qc_review.outputs must exactly cover "
+            "final_review.reviewed_outputs (" + "; ".join(details) + ")"
+        )
+
+    render_report = (
+        related_artifacts.get("render_report")
+        if isinstance(related_artifacts, dict)
+        else None
+    )
+    rendered_outputs = (
+        render_report.get("outputs") if isinstance(render_report, dict) else None
+    )
+    rendered_by_path = {
+        output.get("path").strip(): output
+        for output in rendered_outputs or []
+        if isinstance(output, dict)
+        and isinstance(output.get("path"), str)
+        and output.get("path").strip()
+    }
+    if rendered_by_path and set(rendered_by_path) != reviewed_paths:
+        missing = sorted(set(rendered_by_path) - reviewed_paths)
+        extra = sorted(reviewed_paths - set(rendered_by_path))
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(repr(path) for path in missing))
+        if extra:
+            details.append("unknown " + ", ".join(repr(path) for path in extra))
+        raise jsonschema.ValidationError(
+            f"{pipeline_type} technical_qc_review.outputs must exactly cover "
+            "render_report.outputs (" + "; ".join(details) + ")"
+        )
+
+    if not rendered_by_path and not explicit_reviewed_paths:
+        primary_output_path = final_review.get("output_path")
+        expected_primary_paths = (
+            {primary_output_path.strip()}
+            if isinstance(primary_output_path, str) and primary_output_path.strip()
+            else set()
+        )
+        if expected_primary_paths and expected_primary_paths != reviewed_paths:
+            missing = sorted(expected_primary_paths - reviewed_paths)
+            extra = sorted(reviewed_paths - expected_primary_paths)
+            details: list[str] = []
+            if missing:
+                details.append("missing " + ", ".join(repr(path) for path in missing))
+            if extra:
+                details.append("unknown " + ", ".join(repr(path) for path in extra))
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review.outputs must exactly cover "
+                "final_review output_path (" + "; ".join(details) + ")"
+            )
+
+    for output_path, rendered in rendered_by_path.items():
+        reviewed_variant = review_by_path[output_path].get("variant")
+        rendered_variant = rendered.get("variant")
+        if (
+            isinstance(rendered_variant, str)
+            and rendered_variant.strip()
+            and (
+                not isinstance(reviewed_variant, str)
+                or reviewed_variant.strip() != rendered_variant.strip()
+            )
+        ):
+            raise jsonschema.ValidationError(
+                f"{pipeline_type} technical_qc_review variant must match "
+                f"render_report.outputs for {output_path!r}"
+            )
+
+
 def _validate_ad_video_final_review_matches_render_report(
     final_review: dict[str, Any],
     render_report: dict[str, Any],
@@ -2594,6 +2816,12 @@ def validate_artifact(
         _validate_ad_video_render_report(data, related_artifacts=related_artifacts)
     if name == "final_review" and _is_ad_video_final_review(pipeline_type):
         _validate_ad_video_final_review(data, related_artifacts=related_artifacts)
+    if name == "final_review":
+        _validate_contextual_technical_qc_review(
+            data,
+            pipeline_type=pipeline_type,
+            related_artifacts=related_artifacts,
+        )
     if name == "decision_log":
         _validate_decision_log(data)
 

--- a/schemas/artifacts/final_review.schema.json
+++ b/schemas/artifacts/final_review.schema.json
@@ -43,6 +43,149 @@
             }
           }
         },
+        "technical_qc_review": {
+          "type": "object",
+          "description": "Contextual disposition of technical_qc warnings. The canonical tool supplies measurements; the agent classifies findings against inspected media and approved editorial artifacts.",
+          "required": ["outputs", "unresolved_count"],
+          "additionalProperties": false,
+          "properties": {
+            "outputs": {
+              "type": "array",
+              "minItems": 1,
+              "description": "One contextual review for every rendered output covered by final_review.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "output_path",
+                  "report_path",
+                  "scan_status",
+                  "warning_count",
+                  "findings",
+                  "supplemental_checks",
+                  "unresolved_count"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "output_path": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "variant": { "type": "string", "minLength": 1 },
+                  "report_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Project-relative path to the technical_qc report for this exact render."
+                  },
+                  "scan_status": {
+                    "type": "string",
+                    "enum": ["pass", "pass_with_warnings", "fail"],
+                    "description": "Status copied from the canonical technical_qc report."
+                  },
+                  "warning_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Warning count copied from technical_qc.summary.warning_count."
+                  },
+                  "findings": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "source",
+                        "disposition",
+                        "reason",
+                        "evidence_refs",
+                        "context_refs",
+                        "recommended_action"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "source": {
+                          "type": "string",
+                          "enum": ["technical_qc", "supplemental"]
+                        },
+                        "start_seconds": { "type": "number", "minimum": 0 },
+                        "end_seconds": { "type": "number", "minimum": 0 },
+                        "disposition": {
+                          "type": "string",
+                          "enum": ["defect", "intentional", "uncertain"]
+                        },
+                        "reason": { "type": "string", "minLength": 1 },
+                        "evidence_refs": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": { "type": "string", "minLength": 1 }
+                        },
+                        "context_refs": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": { "type": "string", "minLength": 1 }
+                        },
+                        "recommended_action": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "re_render",
+                            "revise_edit",
+                            "remix_audio",
+                            "human_review"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "supplemental_checks": {
+                    "type": "array",
+                    "description": "Governed project-scoped diagnostics created only when registry tools cannot answer a specific question.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "purpose",
+                        "method",
+                        "lifecycle",
+                        "artifact_ref",
+                        "decision_log_ref",
+                        "result",
+                        "limitations"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "purpose": { "type": "string", "minLength": 1 },
+                        "method": {
+                          "type": "string",
+                          "enum": ["project_script", "project_tool"]
+                        },
+                        "lifecycle": {
+                          "type": "string",
+                          "const": "project_only",
+                          "description": "Supplemental diagnostics are local evidence, not a shared-tool compatibility commitment."
+                        },
+                        "artifact_ref": { "type": "string", "minLength": 1 },
+                        "decision_log_ref": { "type": "string", "minLength": 1 },
+                        "result": {
+                          "type": "string",
+                          "enum": ["supports_defect", "supports_intentional", "inconclusive"]
+                        },
+                        "limitations": { "type": "string", "minLength": 1 }
+                      }
+                    }
+                  },
+                  "unresolved_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            },
+            "unresolved_count": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Aggregate number of defect or uncertain findings across reviewed outputs that still block a passing final review."
+            }
+          }
+        },
         "visual_spotcheck": {
           "type": "object",
           "description": "Sample frames inspected from opening, middle, climax, ending",
@@ -185,5 +328,54 @@
     },
     "metadata": { "type": "object" }
   },
+  "allOf": [
+    {
+      "if": {
+        "required": ["status", "checks"],
+        "properties": {
+          "status": { "const": "pass" },
+          "checks": { "required": ["technical_qc_review"] }
+        }
+      },
+      "then": {
+        "properties": {
+          "checks": {
+            "properties": {
+              "technical_qc_review": {
+                "properties": {
+                  "unresolved_count": { "const": 0 },
+                  "outputs": {
+                    "items": {
+                      "properties": {
+                        "unresolved_count": { "const": 0 },
+                        "scan_status": {
+                          "enum": ["pass", "pass_with_warnings"]
+                        },
+                        "findings": {
+                          "items": {
+                            "properties": {
+                              "disposition": { "const": "intentional" },
+                              "recommended_action": { "const": "none" }
+                            }
+                          }
+                        },
+                        "supplemental_checks": {
+                          "items": {
+                            "properties": {
+                              "result": { "const": "supports_intentional" }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "additionalProperties": false
 }

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -382,6 +382,7 @@ Cross-cutting skills that apply to all pipelines:
 | Video Reference Analyst | `meta/video-reference-analyst.md` | Reference-video analysis and reference-vs-source-footage routing |
 | GenUI Interaction | `meta/genui-interaction.md` | A2UI/CopilotKit GenUI sessions, ui_session_response review, compatibility surface fallback, and CLI fallback |
 | Reviewer | `meta/reviewer.md` | Self-review protocol after every stage |
+| Technical QC Context Review | `meta/technical-qc-review.md` | Hybrid deterministic scan + evidence-backed Agent disposition, with governed project-scoped supplemental diagnostics |
 | Checkpoint Protocol | `meta/checkpoint-protocol.md` | When/how to checkpoint and request human approval |
 | Skill Creator | `meta/skill-creator.md` | Dynamically create new skills during pipeline runs |
 | Animation Runtime Selector | `meta/animation-runtime-selector.md` | Choose render runtime + animation library per scene |

--- a/skills/meta/reviewer.md
+++ b/skills/meta/reviewer.md
@@ -329,6 +329,17 @@ Run at **compose** and **publish** stages. Ensures the agent reviewed the actual
    - `subtitle_check` must report presence/absence
    - Any check with missing data: **SUGGESTION** — "Self-review check [X] has incomplete data"
 4. **Promise preservation**: If `promise_preservation.silent_downgrade_detected` is true: **CRITICAL** — "Self-review detected silent downgrade from motion-led to still-led."
+5. **Contextual Technical QC**: When the compose stage declares `technical_qc`,
+   read `skills/meta/technical-qc-review.md` and verify that
+   `final_review.checks.technical_qc_review.outputs[]` covers every rendered
+   output. Every context-sensitive warning needs evidence plus a `defect`,
+   `intentional`, or `uncertain` disposition. A passing review requires only
+   intentional findings, no inconclusive supplemental diagnostics, and both
+   per-output and aggregate `unresolved_count == 0`. Each output's copied
+   `warning_count` must equal its number of `source: "technical_qc"` findings.
+   Missing evidence or an
+   Agent-authored diagnostic that bypasses the capability-extension protocol is
+   **CRITICAL**.
 
 ### At publish stage:
 1. Verify that `final_review` was passed through as a required artifact

--- a/skills/meta/technical-qc-review.md
+++ b/skills/meta/technical-qc-review.md
@@ -1,0 +1,221 @@
+# Technical QC Context Review
+
+## When to Use
+
+Use this skill after `technical_qc` has inspected a rendered output and before
+the compose-stage `final_review` is allowed to pass. The canonical scan finds
+objective delivery failures and candidate signal anomalies. This skill teaches
+the agent how to decide whether a candidate anomaly is a real defect, an
+intentional editorial choice, or still uncertain.
+
+This is a hybrid contract:
+
+| Layer | Responsibility |
+|-------|----------------|
+| `technical_qc` | Repeatable FFmpeg/ffprobe measurement, parsing, and portable report output |
+| This skill + the agent | Contextual interpretation against the approved plan and the rendered evidence |
+| Capability extension | Audited, project-scoped supplemental diagnostics only when the registry has a real gap |
+
+Hard-code measurement, not creative meaning. A detected interval is evidence,
+not proof that the edit is wrong.
+
+## Coverage Boundary
+
+The canonical tool currently covers decode integrity, stream presence,
+delivery-profile metadata, black/freeze/silence candidate intervals, integrated
+loudness, and true peak. A clean report makes claims only about those checks.
+
+It does not currently prove the absence of sub-threshold black flashes,
+gradual-fade problems, audio/video synchronization errors, repeated scenes,
+local loudness jumps, subtitle safe-area failures, generative visual defects,
+or aesthetic pacing problems. Do not describe `technical_qc.status == "pass"`
+as proof that the whole video is creatively or technically flawless. Route an
+actually required uncovered check through the governed supplemental path in
+Step 5. Keep that diagnostic project-only by default instead of expanding the
+shared Python tool set.
+
+## Required Inputs
+
+- The saved `technical_qc` JSON report for the exact render under review
+- The rendered video
+- `scene_plan` when available
+- `edit_decisions`, including cuts and transitions
+- The approved audio/subtitle/delivery contract from the relevant proposal or brief
+- `render_report` when reviewing a derivative or multi-output delivery
+
+Do not reuse a review from another render or variant. Every output needs its own
+scan and contextual disposition because crop, timing, audio, and transitions
+can differ.
+
+## Protocol
+
+### 1. Keep deterministic failures deterministic
+
+Treat these as tool or delivery failures, not taste calls:
+
+- `ToolResult.success == false`
+- `technical_qc.status == "fail"`
+- missing or corrupt video streams
+- a requested scan that did not complete
+- explicit delivery-profile mismatches
+
+Do not use visual judgment or a supplemental script to override these results.
+Fix the source, configuration, or render and rerun the canonical scan.
+
+Select `expected` values and threshold overrides from approved project facts.
+Do not silently treat the defaults as platform requirements. For example, use
+the approved loudness target and delivery profile when they exist. Record why
+an override was chosen; never loosen a threshold merely to make a warning
+disappear.
+
+### 2. Build the editorial context map
+
+Before interpreting warnings, map each reported time interval to the artifacts:
+
+- `scene_plan.scenes[]`: scene purpose, motion intent, transition intent
+- `edit_decisions.cuts[]`: cut boundaries, source, type, reason, and
+  `transition_in` / `transition_out` / `transition_duration`
+- `edit_decisions.transitions[]`: global transition windows
+- `edit_decisions.audio`: expected narration, music, SFX, fades, and ducking
+- proposal audio `pause_policy`: approved silence or breath room
+
+Do not infer intent from the filename or from the detector label. If no artifact
+supports the claimed intent, keep the finding `uncertain`.
+
+### 3. Collect evidence at the reported interval
+
+Representative opening/middle/ending frames are not enough for a timecoded
+warning. For every black or freeze interval, use `visual_qa` to extract frames
+immediately before it, near its start, at its midpoint, near its end, and
+immediately after it. Clamp timestamps to the media duration and deduplicate
+overlapping timestamps.
+
+```python
+visual_qa.execute({
+    "operation": "review",
+    "input_path": "<rendered-video>",
+    "timestamps": [before_seconds, start_seconds, midpoint_seconds,
+                   end_seconds, after_seconds],
+    "output_dir": "projects/<project-name>/assets/qc_evidence/<variant>/<finding-id>",
+})
+```
+
+Read every extracted frame. A successful extraction is not a completed review.
+For silence, compare the interval with narration segments, music strategy,
+fades, SFX, and the approved pause policy. Use an audio-level or waveform
+diagnostic only when it answers a remaining question; amplitude alone does not
+establish editorial intent.
+
+Use these checks as guidance:
+
+| Finding | Evidence that supports `intentional` | Evidence that supports `defect` |
+|---------|---------------------------------------|---------------------------------|
+| black | overlaps a declared fade/transition or approved black beat; adjacent frames show the planned transition | occurs inside an active scene, flashes between valid frames, or replaces expected content |
+| freeze | overlaps an approved title/end-card hold or explicitly static beat | contradicts `motion_required`, interrupts expected motion, or appears inside a generated motion clip |
+| silence | matches an approved pause, music break, or intentionally silent deliverable | overlaps expected narration/music/SFX or interrupts a spoken phrase |
+| loudness/clipping | matches an explicit delivery/audio contract and has no unsafe peak | violates the approved loudness range, loses intelligibility, or carries clipping risk |
+
+### 4. Assign a disposition
+
+Every context-sensitive warning must receive exactly one disposition:
+
+- `defect` — evidence contradicts the approved edit or delivery intent; revise
+  and rerender.
+- `intentional` — artifacts and inspected media both support the choice; record
+  the reason and continue.
+- `uncertain` — context or evidence is insufficient; request human review or
+  gather more evidence. Never silently convert this to `intentional`.
+
+Each disposition must include a concrete reason, at least one evidence
+reference, and at least one artifact context reference. A statement such as
+"reviewed and acceptable" without those references is not evidence.
+
+### 5. Use Agent-authored diagnostics only as a governed supplement
+
+The canonical tool is the baseline. If it cannot answer a project-specific
+question, first confirm through registry/preflight that no existing tool covers
+the gap. Then read and follow `skills/meta/capability-extension.md`.
+
+Any Agent-authored diagnostic must:
+
+1. Be project-scoped, idempotent, and saved under
+   `projects/<project-name>/scripts/` or as a project tool.
+2. Produce a project-scoped evidence artifact.
+3. Be logged in `decision_log` with `category: "capability_extension"`.
+4. Be disclosed to the user as a supplemental check.
+5. Record its purpose, method, result, evidence, and limitations in
+   the matching output entry under
+   `final_review.checks.technical_qc_review.outputs[].supplemental_checks`.
+6. Declare `lifecycle: "project_only"`; it creates no compatibility or
+   maintenance promise outside the current project.
+7. Never call an external API without approval.
+8. Never override a canonical decode/profile failure or serve as the sole basis
+   for a passing final review.
+
+Do not promote supplemental diagnostics automatically, even if a similar need
+appears again. Prefer adapting the Skill's reasoning recipe and composing the
+existing stable tools. A shared tool is a separate maintainer-owned product
+decision, outside this production workflow, and requires an explicit maintenance
+owner and compatibility budget.
+
+### 6. Record the review
+
+Write the contextual result to
+`final_review.checks.technical_qc_review`. Include exactly one `outputs[]`
+entry for every render covered by `final_review`; its `output_path` and optional
+`variant` must match `render_report.outputs[]`. Copy `status` and
+`summary.warning_count` from the canonical report into `scan_status` and
+`warning_count`; include exactly one `source: "technical_qc"` finding for each
+reported warning. Example:
+
+```json
+{
+  "outputs": [
+    {
+      "output_path": "renders/output_16x9.mp4",
+      "variant": "16:9",
+      "report_path": "artifacts/technical_qc_primary.json",
+      "scan_status": "pass_with_warnings",
+      "warning_count": 1,
+      "findings": [
+        {
+          "code": "freeze_segment",
+          "source": "technical_qc",
+          "start_seconds": 28.0,
+          "end_seconds": 31.0,
+          "disposition": "intentional",
+          "reason": "The interval is the approved static brand end-card hold.",
+          "evidence_refs": [
+            "assets/qc_evidence/primary/freeze-28/frame_29_5s.jpg"
+          ],
+          "context_refs": [
+            "edit_decisions.cuts[end-card]"
+          ],
+          "recommended_action": "none"
+        }
+      ],
+      "supplemental_checks": [],
+      "unresolved_count": 0
+    }
+  ],
+  "unresolved_count": 0
+}
+```
+
+For a clean scan, keep that output entry's `findings` and
+`supplemental_checks` empty, use `scan_status: "pass"` and `warning_count: 0`,
+and set both the per-output and aggregate `unresolved_count` to `0`. The
+aggregate count is the sum of the per-output counts. Do not invent findings
+merely to populate the block.
+
+### 7. Gate the final review
+
+- Any deterministic failure: `final_review.status = "fail"` or `"revise"`.
+- Any `defect`: revise/rerender, rerun `technical_qc`, and review the new report.
+- Any `uncertain`: keep the review non-passing until more evidence or explicit
+  human review resolves it.
+- Only deterministic PASS plus zero unresolved findings may reach
+  `final_review.status = "pass"`.
+
+An intentional warning remains visible in the audit trail; it is not deleted
+from the canonical report.

--- a/skills/pipelines/ad-video/compose-director.md
+++ b/skills/pipelines/ad-video/compose-director.md
@@ -359,10 +359,19 @@ if blocking_warnings:
 ```
 
 Black, freeze, and silence findings are timecoded warnings because they can be
-intentional. Inspect each reported interval in the actual render. Re-render an
-unintentional interval; record an intentional one in
-`render_report.verification_notes` rather than silently discarding it. A
+intentional. Before interpreting any warning, read and follow
+`skills/meta/technical-qc-review.md`. It requires an evidence-backed
+`defect` / `intentional` / `uncertain` disposition against `scene_plan`,
+`edit_decisions`, the approved audio contract, and frames from the reported
+interval. Re-render a defect; do not pass an uncertain result; retain an
+intentional finding in the audit trail rather than silently discarding it. A
 requested check that could not complete is a failed QC result, not a pass.
+
+The registered `technical_qc` tool remains the canonical baseline. An
+Agent-authored project diagnostic is permitted only for a verified registry
+gap and must follow `skills/meta/capability-extension.md`; it is supplemental
+evidence and cannot override a canonical decode/profile failure or establish a
+pass by itself.
 
 ### Check 6: Subtitle no-overlap (when subtitles enabled)
 
@@ -398,7 +407,9 @@ square, and any `15s` / `15s_short` output is `<=15s`. Run the same
 `technical_qc` procedure for every derivative using its actual expected
 dimensions and duration, and write a distinct report such as
 `artifacts/technical_qc_9x16.json`. Do not add an output to the render report
-until its QC result completed and all warnings were either fixed or reviewed.
+until its QC result completed and all warnings were assigned a disposition through the
+context-review protocol. Do not reuse the primary output's evidence or
+dispositions for a derivative.
 
 ## Render Report Format
 
@@ -452,6 +463,11 @@ The `final_review` must include:
 - `technical_probe` with container, duration, resolution, fps, audio, codec, and
   file-size evidence from the rendered file; derive this from the corresponding
   `technical_qc` report and retain its path in `final_review.metadata`
+- `technical_qc_review.outputs[]` with one entry per rendered output, the exact
+  report path, copied `scan_status` and `warning_count`, an evidence-backed
+  disposition for every context-sensitive warning, any governed supplemental
+  diagnostics, and per-output plus aggregate `unresolved_count == 0` for a
+  passing review
 - `visual_spotcheck` with at least 4 sampled frame paths covering opening,
   middle, climax, and ending
 - `audio_spotcheck` confirming narration, silence, clipping, mix
@@ -487,7 +503,9 @@ status is `revise` or `fail`.
 - [ ] Every `render_report.outputs[]` variant has matching resolution and short variants are `<=15s`
 - [ ] Probe results are PASS, or WARN only with a matching verification note
 - [ ] Every primary and derivative output has a saved `technical_qc` report
-- [ ] No Technical QC failed; every timecoded warning was fixed or explicitly reviewed
+- [ ] No Technical QC failed; every context-sensitive warning has an evidence-backed disposition
+- [ ] `final_review.checks.technical_qc_review.outputs[]` covers every rendered output
+- [ ] Per-output and aggregate `technical_qc_review.unresolved_count == 0`
 - [ ] `render_report.renderer` matches `EP_STATE.render_runtime`
 - [ ] `final_review.status == "pass"` and every required self-review check has evidence
 - [ ] `final_review.output_path` and probe/runtime evidence match `render_report`

--- a/skills/pipelines/talking-head/compose-director.md
+++ b/skills/pipelines/talking-head/compose-director.md
@@ -441,6 +441,12 @@ technical_qc.execute({
 })
 ```
 
+Before interpreting the result, read and follow
+`skills/meta/technical-qc-review.md`. The registered tool is the canonical
+measurement baseline; the Agent supplies editorial judgment only after mapping
+each warning to the scene/edit/audio plan and inspecting evidence from the
+reported interval.
+
 - `ToolResult.success: false` means the file could not be probed or the report
   could not be produced. Treat that as a blocker rather than assuming the
   render passed.
@@ -449,15 +455,25 @@ technical_qc.execute({
   the cause or re-render before submitting.
 - `status: pass_with_warnings` does not automatically block delivery. Inspect
   every reported interval because black, frozen, or silent sections may be
-  intentional editorial choices. Surface unresolved warnings in
-  `render_report` / `final_review`.
+  intentional editorial choices. Assign `defect`, `intentional`, or
+  `uncertain` with evidence and artifact context; surface unresolved warnings
+  in `render_report` / `final_review`.
 - Technical QC is not an aesthetic review and does not replace watching the
   render or inspecting representative frames.
 - Store the report path in `render_report.metadata.technical_qc_report`; map
   its container evidence into `final_review.checks.technical_probe`, and map
-  unresolved interval/audio findings into the corresponding visual/audio
-  review issues. An intentional warning may be recorded as a verification note
-  after the reported interval has actually been watched.
+  every context-sensitive finding into the matching
+  `final_review.checks.technical_qc_review.outputs[]` entry, including the
+  canonical report's `scan_status` and `warning_count`. The warning count must
+  equal the number of `source: "technical_qc"` findings. A passing review
+  requires both its per-output and aggregate `unresolved_count == 0`. An
+  intentional warning may be recorded only after
+  its interval evidence and matching scene/edit/audio context have actually
+  been inspected.
+- If no registered tool answers a remaining project-specific question, follow
+  `skills/meta/capability-extension.md` for a project-scoped diagnostic. Record
+  it as supplemental evidence; it cannot override a canonical technical
+  failure or establish a pass by itself.
 
 Then extract representative frames for visual inspection:
 

--- a/tests/contracts/test_ad_video_chain_integrity.py
+++ b/tests/contracts/test_ad_video_chain_integrity.py
@@ -444,6 +444,21 @@ def _valid_final_review() -> dict:
                 "file_size_bytes": 1200000,
                 "issues": [],
             },
+            "technical_qc_review": {
+                "outputs": [
+                    {
+                        "output_path": "renders/final.mp4",
+                        "variant": "16:9",
+                        "report_path": "artifacts/technical_qc_primary.json",
+                        "scan_status": "pass",
+                        "warning_count": 0,
+                        "findings": [],
+                        "supplemental_checks": [],
+                        "unresolved_count": 0,
+                    }
+                ],
+                "unresolved_count": 0,
+            },
             "visual_spotcheck": {
                 "frames_sampled": 4,
                 "frame_paths": [
@@ -956,6 +971,13 @@ class TestRenderReportOutputCoverage:
 
 
 class TestFinalReviewCompleteness:
+    def test_passing_final_review_requires_contextual_technical_qc(self) -> None:
+        review = _valid_final_review()
+        del review["checks"]["technical_qc_review"]
+
+        with pytest.raises(ValidationError, match="technical_qc_review"):
+            validate_artifact("final_review", review, pipeline_type="ad-video")
+
     def test_passing_final_review_requires_technical_probe_data(self) -> None:
         review = _valid_final_review()
         del review["checks"]["technical_probe"]["valid_container"]
@@ -1066,12 +1088,45 @@ class TestRenderToFinalReviewConsistency:
                 "resolution": "1080x1920",
             },
         ]
+        review["checks"]["technical_qc_review"]["outputs"].append(
+            {
+                "output_path": "renders/final-vertical.mp4",
+                "variant": "9:16",
+                "report_path": "artifacts/technical_qc_9x16.json",
+                "scan_status": "pass",
+                "warning_count": 0,
+                "findings": [],
+                "supplemental_checks": [],
+                "unresolved_count": 0,
+            }
+        )
         validate_artifact(
             "final_review",
             review,
             pipeline_type="ad-video",
             related_artifacts={"render_report": report},
         )
+
+    def test_technical_qc_review_must_cover_every_rendered_output(self) -> None:
+        report = _render_report_with_vertical_derivative()
+        review = _valid_final_review()
+        review["reviewed_outputs"] = [
+            {
+                "path": output["path"],
+                "variant": output["variant"],
+                "duration_seconds": output["duration_seconds"],
+                "resolution": output["resolution"],
+            }
+            for output in report["outputs"]
+        ]
+
+        with pytest.raises(ValidationError, match="technical_qc_review.outputs"):
+            validate_artifact(
+                "final_review",
+                review,
+                pipeline_type="ad-video",
+                related_artifacts={"render_report": report},
+            )
 
     def test_final_review_subtitle_expectation_must_match_proposal(self) -> None:
         proposal = _minimal_production_proposal()

--- a/tests/contracts/test_technical_qc_context_review.py
+++ b/tests/contracts/test_technical_qc_context_review.py
@@ -1,0 +1,403 @@
+"""Contracts for evidence-backed contextual review of Technical QC findings."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from schemas.artifacts import validate_artifact
+
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+FINAL_REVIEW_SCHEMA = ROOT / "schemas" / "artifacts" / "final_review.schema.json"
+CONTEXT_SKILL = ROOT / "skills" / "meta" / "technical-qc-review.md"
+REVIEWER_SKILL = ROOT / "skills" / "meta" / "reviewer.md"
+
+
+def _review_with_context(*, status: str = "pass", unresolved_count: int = 0) -> dict:
+    return {
+        "version": "1.0",
+        "output_path": "renders/final.mp4",
+        "status": status,
+        "checks": {
+            "technical_probe": {},
+            "visual_spotcheck": {},
+            "audio_spotcheck": {},
+            "promise_preservation": {},
+            "subtitle_check": {},
+            "technical_qc_review": {
+                "outputs": [
+                    {
+                        "output_path": "renders/final.mp4",
+                        "report_path": "artifacts/technical_qc.json",
+                        "scan_status": "pass_with_warnings",
+                        "warning_count": 1,
+                        "findings": [
+                            {
+                                "code": "freeze_segment",
+                                "source": "technical_qc",
+                                "start_seconds": 28.0,
+                                "end_seconds": 31.0,
+                                "disposition": "intentional",
+                                "reason": "Matches the approved static end-card hold.",
+                                "evidence_refs": [
+                                    "assets/qc_evidence/freeze-28/frame_29_5s.jpg"
+                                ],
+                                "context_refs": ["edit_decisions.cuts[end-card]"],
+                                "recommended_action": "none",
+                            }
+                        ],
+                        "supplemental_checks": [],
+                        "unresolved_count": unresolved_count,
+                    }
+                ],
+                "unresolved_count": unresolved_count,
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def final_review_schema() -> dict:
+    return json.loads(FINAL_REVIEW_SCHEMA.read_text(encoding="utf-8"))
+
+
+def test_final_review_accepts_evidence_backed_intentional_finding(
+    final_review_schema: dict,
+) -> None:
+    jsonschema.validate(_review_with_context(), final_review_schema)
+
+
+def test_contextual_finding_requires_evidence_and_artifact_context(
+    final_review_schema: dict,
+) -> None:
+    review = _review_with_context()
+    output_review = review["checks"]["technical_qc_review"]["outputs"][0]
+    finding = output_review["findings"][0]
+    finding["evidence_refs"] = []
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(review, final_review_schema)
+
+    finding["evidence_refs"] = ["assets/qc_evidence/frame.jpg"]
+    finding["context_refs"] = []
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(review, final_review_schema)
+
+
+def test_passing_review_rejects_unresolved_contextual_findings(
+    final_review_schema: dict,
+) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            _review_with_context(unresolved_count=1),
+            final_review_schema,
+        )
+
+    jsonschema.validate(
+        _review_with_context(status="revise", unresolved_count=1),
+        final_review_schema,
+    )
+
+
+def test_same_measurement_can_receive_different_contextual_dispositions(
+    final_review_schema: dict,
+) -> None:
+    intentional = _review_with_context()
+    jsonschema.validate(intentional, final_review_schema)
+
+    defect = deepcopy(intentional)
+    defect["status"] = "revise"
+    contextual_review = defect["checks"]["technical_qc_review"]
+    contextual_review["unresolved_count"] = 1
+    output_review = contextual_review["outputs"][0]
+    output_review["unresolved_count"] = 1
+    finding = output_review["findings"][0]
+    finding.update(
+        {
+            "disposition": "defect",
+            "reason": "The frozen interval interrupts a cut marked motion_required.",
+            "context_refs": ["scene_plan.scenes[motion-demo]"],
+            "recommended_action": "re_render",
+        }
+    )
+    jsonschema.validate(defect, final_review_schema)
+
+    defect["status"] = "pass"
+    contextual_review["unresolved_count"] = 0
+    output_review["unresolved_count"] = 0
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(defect, final_review_schema)
+
+
+def test_talking_head_pass_requires_context_review_and_output_coverage() -> None:
+    review = _review_with_context()
+    render_report = {
+        "version": "1.0",
+        "outputs": [
+            {
+                "path": "renders/final.mp4",
+                "format": "mp4",
+                "resolution": "1080x1920",
+                "duration_seconds": 31.0,
+            }
+        ],
+    }
+    validate_artifact(
+        "final_review",
+        review,
+        pipeline_type="talking-head",
+        related_artifacts={"render_report": render_report},
+    )
+
+    missing = deepcopy(review)
+    del missing["checks"]["technical_qc_review"]
+    with pytest.raises(jsonschema.ValidationError, match="technical_qc_review"):
+        validate_artifact("final_review", missing, pipeline_type="talking-head")
+
+    wrong_output = deepcopy(review)
+    wrong_output["checks"]["technical_qc_review"]["outputs"][0][
+        "output_path"
+    ] = "renders/other.mp4"
+    with pytest.raises(jsonschema.ValidationError, match="exactly cover"):
+        validate_artifact(
+            "final_review",
+            wrong_output,
+            pipeline_type="talking-head",
+            related_artifacts={"render_report": render_report},
+        )
+
+    with pytest.raises(jsonschema.ValidationError, match="final_review output_path"):
+        validate_artifact(
+            "final_review",
+            wrong_output,
+            pipeline_type="talking-head",
+        )
+
+
+def test_talking_head_multi_output_uses_render_report_as_coverage_source() -> None:
+    review = _review_with_context()
+    review["checks"]["technical_qc_review"]["outputs"].append(
+        {
+            "output_path": "renders/final-square.mp4",
+            "variant": "1:1",
+            "report_path": "artifacts/technical_qc_square.json",
+            "scan_status": "pass",
+            "warning_count": 0,
+            "findings": [],
+            "supplemental_checks": [],
+            "unresolved_count": 0,
+        }
+    )
+    render_report = {
+        "version": "1.0",
+        "outputs": [
+            {
+                "path": "renders/final.mp4",
+                "format": "mp4",
+                "resolution": "1080x1920",
+                "duration_seconds": 31.0,
+            },
+            {
+                "path": "renders/final-square.mp4",
+                "variant": "1:1",
+                "format": "mp4",
+                "resolution": "1080x1080",
+                "duration_seconds": 31.0,
+            },
+        ],
+    }
+
+    validate_artifact(
+        "final_review",
+        review,
+        pipeline_type="talking-head",
+        related_artifacts={"render_report": render_report},
+    )
+
+
+def test_context_review_rejects_incomplete_or_reversed_time_ranges() -> None:
+    review = _review_with_context(status="revise")
+    finding = review["checks"]["technical_qc_review"]["outputs"][0]["findings"][0]
+    del finding["end_seconds"]
+
+    with pytest.raises(jsonschema.ValidationError, match="both start_seconds"):
+        validate_artifact("final_review", review, pipeline_type="talking-head")
+
+    finding["end_seconds"] = 20.0
+    with pytest.raises(jsonschema.ValidationError, match="greater than or equal"):
+        validate_artifact("final_review", review, pipeline_type="talking-head")
+
+
+def test_context_review_is_backward_compatible_outside_passing_qc_pipelines() -> None:
+    review = _review_with_context(status="revise")
+    del review["checks"]["technical_qc_review"]
+
+    validate_artifact("final_review", review, pipeline_type="ad-video")
+    validate_artifact("final_review", review, pipeline_type="talking-head")
+    review["status"] = "pass"
+    validate_artifact("final_review", review, pipeline_type="slideshow")
+
+
+def test_context_review_counts_unresolved_findings_consistently() -> None:
+    review = _review_with_context(status="revise", unresolved_count=0)
+    finding = review["checks"]["technical_qc_review"]["outputs"][0]["findings"][0]
+    finding.update(
+        {
+            "disposition": "uncertain",
+            "reason": "The available frames do not establish whether the hold is intended.",
+            "recommended_action": "human_review",
+        }
+    )
+
+    with pytest.raises(jsonschema.ValidationError, match="unresolved_count"):
+        validate_artifact("final_review", review, pipeline_type="talking-head")
+
+    output_review = review["checks"]["technical_qc_review"]["outputs"][0]
+    output_review["unresolved_count"] = 1
+    review["checks"]["technical_qc_review"]["unresolved_count"] = 1
+    validate_artifact("final_review", review, pipeline_type="talking-head")
+
+
+def test_context_review_covers_every_canonical_warning() -> None:
+    review = _review_with_context(status="revise")
+    output_review = review["checks"]["technical_qc_review"]["outputs"][0]
+    output_review["warning_count"] = 2
+
+    with pytest.raises(jsonschema.ValidationError, match="warning_count"):
+        validate_artifact("final_review", review, pipeline_type="talking-head")
+
+    output_review["scan_status"] = "pass"
+    output_review["warning_count"] = 1
+    with pytest.raises(jsonschema.ValidationError, match="scan_status='pass'"):
+        validate_artifact("final_review", review, pipeline_type="talking-head")
+
+
+def test_context_review_matches_render_variant_after_normalization() -> None:
+    review = _review_with_context()
+    output_review = review["checks"]["technical_qc_review"]["outputs"][0]
+    output_review["variant"] = " primary "
+    render_report = {
+        "version": "1.0",
+        "outputs": [
+            {
+                "path": "renders/final.mp4",
+                "variant": "primary",
+                "format": "mp4",
+                "resolution": "1080x1920",
+                "duration_seconds": 31.0,
+            }
+        ],
+    }
+    validate_artifact(
+        "final_review",
+        review,
+        pipeline_type="talking-head",
+        related_artifacts={"render_report": render_report},
+    )
+
+    output_review["variant"] = "landscape"
+    with pytest.raises(jsonschema.ValidationError, match="variant must match"):
+        validate_artifact(
+            "final_review",
+            review,
+            pipeline_type="talking-head",
+            related_artifacts={"render_report": render_report},
+        )
+
+
+def test_supplemental_diagnostic_requires_capability_extension_provenance(
+    final_review_schema: dict,
+) -> None:
+    review = _review_with_context(status="revise", unresolved_count=1)
+    supplemental = {
+        "purpose": "Inspect a project-specific repeated-frame pattern.",
+        "method": "project_script",
+        "lifecycle": "project_only",
+        "artifact_ref": "artifacts/repeated_frame_diagnostic.json",
+        "decision_log_ref": "artifacts/decision_log.json#ext-001",
+        "result": "inconclusive",
+        "limitations": "The heuristic does not establish editorial intent.",
+    }
+    output_review = review["checks"]["technical_qc_review"]["outputs"][0]
+    output_review["supplemental_checks"] = [supplemental]
+    jsonschema.validate(review, final_review_schema)
+
+    broken = deepcopy(review)
+    del broken["checks"]["technical_qc_review"]["outputs"][0][
+        "supplemental_checks"
+    ][0]["decision_log_ref"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(broken, final_review_schema)
+
+    wrong_lifecycle = deepcopy(review)
+    wrong_lifecycle["checks"]["technical_qc_review"]["outputs"][0][
+        "supplemental_checks"
+    ][0]["lifecycle"] = "shared"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(wrong_lifecycle, final_review_schema)
+
+
+def test_context_skill_enforces_hybrid_boundary() -> None:
+    text = CONTEXT_SKILL.read_text(encoding="utf-8").lower()
+
+    for required in (
+        "hard-code measurement, not creative meaning",
+        "defect",
+        "intentional",
+        "uncertain",
+        "visual_qa",
+        "capability-extension.md",
+        "project_only",
+        "do not promote",
+        "never override",
+        "sole basis",
+    ):
+        assert required in text
+
+    reviewer = REVIEWER_SKILL.read_text(encoding="utf-8")
+    assert "skills/meta/technical-qc-review.md" in reviewer
+    assert "technical_qc_review.outputs[]" in reviewer
+
+
+@pytest.mark.parametrize(
+    ("manifest_name", "required_skill", "director_name"),
+    [
+        (
+            "ad-video.yaml",
+            "skills/meta/technical-qc-review.md",
+            "ad-video/compose-director.md",
+        ),
+        (
+            "talking-head.yaml",
+            "meta/technical-qc-review",
+            "talking-head/compose-director.md",
+        ),
+    ],
+)
+def test_existing_qc_pipelines_require_context_review_skill(
+    manifest_name: str,
+    required_skill: str,
+    director_name: str,
+) -> None:
+    manifest = yaml.safe_load(
+        (ROOT / "pipeline_defs" / manifest_name).read_text(encoding="utf-8")
+    )
+    assert required_skill in manifest["required_skills"]
+
+    compose = next(stage for stage in manifest["stages"] if stage["name"] == "compose")
+    assert any(
+        "technical_qc_review" in criterion
+        for criterion in compose["success_criteria"]
+    )
+
+    director = (ROOT / "skills" / "pipelines" / director_name).read_text(
+        encoding="utf-8"
+    )
+    assert "skills/meta/technical-qc-review.md" in director
+    assert "technical_qc_review" in director


### PR DESCRIPTION
## Summary

Adds an evidence-backed contextual review layer on top of the deterministic
Technical QC scan.

The canonical `technical_qc` tool remains responsible for repeatable
FFmpeg/ffprobe measurements. The Agent now interprets context-sensitive
warnings against inspected media, scene plans, edit decisions, and approved
audio intent.

This prevents intentional fades, end-card holds, and pauses from being treated
as automatic failures while preserving deterministic delivery failures as hard
blockers.

## Related issue

Follow-up to #12 and its review feedback; no separate issue filed.

## Changes

- Add a `technical-qc-review` meta skill defining the boundary between deterministic measurement and contextual judgment.
- Require every context-sensitive warning to be classified as `defect`, `intentional`, or `uncertain`.
- Require time-local media evidence and scene/edit/audio context for every disposition.
- Copy the canonical scan status and warning count into each output review.
- Require the warning count to match the number of reviewed Technical QC findings.
- Prevent defect, uncertain, failed, or incomplete results from being marked as PASS.
- Validate finding time ranges, output paths, report paths, and render variants.
- Require separate QC review coverage for primary and derivative outputs.
- Allow Agent-authored diagnostics only as governed `project_only` evidence.
- Integrate contextual QC review into ad-video and talking-head compose workflows.
- Add contract tests for contextual disposition, multi-output coverage, warning completeness, lifecycle governance, and backward compatibility.
- Document the hybrid QC architecture.

## Testing

- Contextual QC contract tests:
  - 15 passed
- Contextual QC, ad-video chain, and JSON Schema tests:
  - 240 passed
- Core contract suite:
  - 1211 passed, 1 deselected
- `tests/tools/test_technical_qc.py`
  - 30 passed
- Real FFmpeg media smoke tests:
  - 6 passed
- Python compilation:
  - passed
- `git diff --check`
  - passed

Local Windows-wide testing also exposed pre-existing path-format and local Git
fixture failures in unrelated modules. No affected tool implementation is
changed by this PR.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.